### PR TITLE
added i18n tests; added top-level refs to app,filesystem, i18n, and stor...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 packages
 pubspec.lock
 out
+.project

--- a/.settings/com.google.dart.tools.core.prefs
+++ b/.settings/com.google.dart.tools.core.prefs
@@ -1,0 +1,3 @@
+#Mon May 20 09:59:09 PDT 2013
+dart2jsFlags=--disallow-unsafe-eval
+eclipse.preferences.version=1

--- a/lib/chrome.dart
+++ b/lib/chrome.dart
@@ -1,11 +1,27 @@
 library chrome;
 
-import 'package:js/js.dart';
+import 'src/app.dart';
+export 'src/app.dart';
+
+import 'src/file_system.dart';
+export 'src/file_system.dart';
+
+import 'src/i18n.dart';
+export 'src/i18n.dart';
 
 import 'src/runtime.dart';
 export 'src/runtime.dart';
 
 import 'src/serial.dart';
 export 'src/serial.dart';
+
+import 'src/storage.dart';
+export 'src/storage.dart';
+
+final ChromeApp app = new ChromeApp();
+final ChromeFileSystem fileSystem  = new ChromeFileSystem();
+final ChromeI18n i18n = new ChromeI18n();
+//final ChromeRuntime runtime = new ChromeRuntime();
+final ChromeStorage storage = new ChromeStorage();
 
 // part 'src/storage.dart';

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -25,7 +25,7 @@ class ChromeWindow {
   AppWindow current() {
     if (_current == null) {
       _current = js.scoped(() {
-        return new AppWindow(chrome.app.window.current());
+        return new AppWindow(chromeProxy.app.window.current());
       });
     }
 
@@ -46,7 +46,7 @@ class ChromeWindow {
 //        options['bounds'] = bounds;
 //      }
 
-      chrome.app.window.create(
+      chromeProxy.app.window.create(
           url,
           js.map(options),
           new js.Callback.once((var proxy) => completer.complete(new AppWindow(proxy))));
@@ -58,7 +58,7 @@ class ChromeWindow {
   // chrome.app.window.onClosed.addListener(function() {...});
   void onClosed(var callback) {
     return js.scoped(() {
-      return chrome.app.window.onClosed.addListener(new js.Callback.once(() {
+      return chromeProxy.app.window.onClosed.addListener(new js.Callback.once(() {
         callback();
       }));
     });
@@ -131,7 +131,7 @@ class AppWindow {
   }
 
   void dispose() {
-    jsRelease(proxy);
+    js.release(proxy);
   }
 }
 

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -2,16 +2,14 @@ library common;
 
 import 'dart:async';
 import 'dart:html';
-import 'dart:web_audio';
 
 import 'package:js/js.dart' as js;
 import 'package:logging/logging.dart';
 
-dynamic get context => js.context;
-dynamic get chrome => context.chrome;
+dynamic get chromeProxy => js.context.chrome;
 
 String get lastError {
-  js.Proxy error = chrome.runtime['lastError'];
+  js.Proxy error = chromeProxy.runtime['lastError'];
 
   if (error != null) {
     return error['message'];
@@ -27,6 +25,7 @@ String toTitleCase(String str) {
     return str.substring(0, 1).toUpperCase() + str.substring(1).toLowerCase();
   }
 }
+
 /**
  * Strip off one set of leading and trailing single or double quotes.
  */
@@ -46,21 +45,6 @@ String stripQuotes(String str) {
   return str;
 }
 
-void jsRelease(js.Proxy proxy) {
-  // TODO: workaround a js interop / CSP bug? seems to only happen with ace
-  try {
-    js.release(proxy);
-  } catch (ex) {
-    try {
-      print("Exception call js.release() on ${proxy}");
-    } catch (_) {
-
-    }
-
-    print(ex);
-  }
-}
-
 bool isLinux() {
   return _platform().indexOf('linux') != -1;
 }
@@ -77,18 +61,4 @@ String _platform() {
   String str = window.navigator.platform;
 
   return (str != null) ? str.toLowerCase() : '';
-}
-
-AudioContext _ctx;
-
-void beep() {
-  if (_ctx == null) {
-    _ctx = new AudioContext();
-  }
-
-  OscillatorNode osc = _ctx.createOscillator();
-
-  osc.connect(_ctx.destination, 0, 0);
-  osc.start(0);
-  osc.stop(_ctx.currentTime + 0.1);
 }

--- a/lib/src/file_system.dart
+++ b/lib/src/file_system.dart
@@ -58,7 +58,7 @@ class ChromeFileSystem {
         }
       });
 
-      chrome.fileSystem.chooseEntry(js.map({'type': 'openFile'}), callback);
+      chromeProxy.fileSystem.chooseEntry(js.map({'type': 'openFile'}), callback);
     });
 
     return completer.future;
@@ -76,7 +76,7 @@ class ChromeFileSystem {
         }
       });
 
-      chrome.fileSystem.chooseEntry(js.map({'type': 'saveFile'}), callback);
+      chromeProxy.fileSystem.chooseEntry(js.map({'type': 'saveFile'}), callback);
     });
 
     return completer.future;
@@ -95,7 +95,7 @@ class ChromeFileSystem {
         completer.complete(path);
       });
 
-      chrome.fileSystem.getDisplayPath(fileEntry._proxy, callback);
+      chromeProxy.fileSystem.getDisplayPath(fileEntry._proxy, callback);
 
       return completer.future;
     });
@@ -112,7 +112,7 @@ class ChromeFileSystem {
         completer.complete(writeable);
       });
 
-      chrome.fileSystem.isWritableEntry(fileEntry._proxy, callback);
+      chromeProxy.fileSystem.isWritableEntry(fileEntry._proxy, callback);
 
       return completer.future;
     });
@@ -123,7 +123,7 @@ class ChromeFileSystem {
    */
   ChromeFileEntry getEntryById(String id) {
     return js.scoped(() {
-      return new ChromeFileEntry(chrome.fileSystem.getEntryById(id));
+      return new ChromeFileEntry(chromeProxy.fileSystem.getEntryById(id));
     });
   }
 
@@ -135,7 +135,7 @@ class ChromeFileSystem {
    */
   String getEntryId(ChromeFileEntry fileEntry) {
     return js.scoped(() {
-      return chrome.fileSystem.getEntryId(fileEntry._proxy);
+      return chromeProxy.fileSystem.getEntryId(fileEntry._proxy);
     });
   }
 }
@@ -232,7 +232,7 @@ class ChromeFileEntry {
       });
 
       js.Callback callback = new js.Callback.once((var file) {
-        var reader = new js.Proxy(context.FileReader);
+        var reader = new js.Proxy(js.context.FileReader);
         (reader as dynamic).onloadend = contentsCallback;
         (reader as dynamic).readAsText(file);
       });
@@ -269,7 +269,7 @@ class ChromeFileEntry {
 
       js.Callback writerCallback = new js.Callback.once((var writer) {
         // blob = new Blob([contents])
-        var blob = new js.Proxy(context.Blob, js.array([contents]));
+        var blob = new js.Proxy(js.context.Blob, js.array([contents]));
 
         writer.onwriteend = writeEndCallback;
         writer.onerror = errorCallback;
@@ -280,13 +280,13 @@ class ChromeFileEntry {
         writeableEntry.createWriter(writerCallback, errorCallback);
       });
 
-      chrome.fileSystem.getWritableEntry(_proxy, writeableCallback);
+      chromeProxy.fileSystem.getWritableEntry(_proxy, writeableCallback);
     });
 
     return completer.future;
   }
 
   void dispose() {
-    jsRelease(_proxy);
+    js.release(_proxy);
   }
 }

--- a/lib/src/i18n.dart
+++ b/lib/src/i18n.dart
@@ -31,7 +31,7 @@ class ChromeI18n {
   String getMessage(String key, [List<String> substitutions]) {
     return js.scoped(() {
       // TODO: use the substitutions param
-      return chrome.i18n.getMessage(key);
+      return chromeProxy.i18n.getMessage(key);
     });
   }
 
@@ -47,7 +47,7 @@ class ChromeI18n {
         completer.complete(new js_wrapping.JsArrayToListAdapter.fromProxy(languages).toList());
       });
 
-      chrome.i18n.getAcceptLanguages(callback);
+      chromeProxy.i18n.getAcceptLanguages(callback);
 
       return completer.future;
     });

--- a/lib/src/storage.dart
+++ b/lib/src/storage.dart
@@ -31,7 +31,7 @@ class StorageArea {
    */
   num get QUOTA_BYTES {
     return js.scoped(() {
-      return chrome.storage[_type].QUOTA_BYTES;
+      return chromeProxy.storage[_type].QUOTA_BYTES;
     });
   }
 
@@ -70,9 +70,9 @@ class StorageArea {
       });
 
       if (keys == null) {
-        chrome.storage[_type].get(null, callback);
+        chromeProxy.storage[_type].get(null, callback);
       } else {
-        chrome.storage[_type].get(js.array(keys), callback);
+        chromeProxy.storage[_type].get(js.array(keys), callback);
       }
     });
 
@@ -96,7 +96,7 @@ class StorageArea {
         }
       });
 
-      chrome.storage[_type].set(js.map(items), callback);
+      chromeProxy.storage[_type].set(js.map(items), callback);
     });
 
     return completer.future;
@@ -119,7 +119,7 @@ class StorageArea {
         }
       });
 
-      chrome.storage[_type].remove(js.array(keys), callback);
+      chromeProxy.storage[_type].remove(js.array(keys), callback);
     });
 
     return completer.future;
@@ -142,7 +142,7 @@ class StorageArea {
         }
       });
 
-      chrome.storage[_type].clear(callback);
+      chromeProxy.storage[_type].clear(callback);
     });
 
     return completer.future;
@@ -159,25 +159,25 @@ class SyncStorageArea extends StorageArea {
 
   num get MAX_ITEMS {
     return js.scoped(() {
-      return chrome.storage[_type].MAX_ITEMS;
+      return chromeProxy.storage[_type].MAX_ITEMS;
     });
   }
 
   num get QUOTA_BYTES_PER_ITEM {
     return js.scoped(() {
-      return chrome.storage[_type].MAX_ITEMS;
+      return chromeProxy.storage[_type].MAX_ITEMS;
     });
   }
 
   num get MAX_WRITE_OPERATIONS_PER_HOUR {
     return js.scoped(() {
-      return chrome.storage[_type].MAX_ITEMS;
+      return chromeProxy.storage[_type].MAX_ITEMS;
     });
   }
 
   num get MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE {
     return js.scoped(() {
-      return chrome.storage[_type].MAX_ITEMS;
+      return chromeProxy.storage[_type].MAX_ITEMS;
     });
   }
 

--- a/test/harness_browser.dart
+++ b/test/harness_browser.dart
@@ -9,6 +9,7 @@ import 'package:js/js.dart' as js;
 
 import 'package:chrome/chrome.dart';
 
+part 'src/test_i18n.dart';
 part 'src/test_runtime.dart';
 part 'src/test_serial.dart';
 
@@ -38,6 +39,7 @@ main() {
     }
   });
 
+  new TestI18N().main();
   new TestRuntime().main();
   new TestSerial().main();
 }

--- a/test/manifest.json
+++ b/test/manifest.json
@@ -3,7 +3,11 @@
   "name": "chrome.dart - test",
   "version": "1",
   "minimum_chrome_version": "23",
-  "permissions": ["serial"],
+  "permissions": [
+    "serial",
+    { "fileSystem": ["write"] },
+    "storage"
+  ],
   "app": {
     "background": {
       "scripts": ["main.js"]

--- a/test/src/test_i18n.dart
+++ b/test/src/test_i18n.dart
@@ -1,0 +1,20 @@
+part of harness_browser;
+
+class TestI18N {
+  void main() {
+    group('chrome.i18n', () {
+      test('ui_locale', () {
+        print('locale = ${i18n.ui_locale}');
+        expect(i18n.ui_locale, isNotNull);
+      });
+      test('getAcceptLanguages', () {
+        Future future = i18n.getAcceptLanguages().then((List<String> languages) {
+          expect(languages, isList);
+          expect(languages.length, greaterThan(0));        
+        });
+        
+        expect(future, completes);
+      });
+    });
+  }
+}


### PR DESCRIPTION
added i18n tests; added top-level refs to app,filesystem, i18n, and storage

This adds references to the app.dart, file_system, storage, and i18n.dart code from chrome.dart. It also adds top-level variables in chrome.dart so importers can do this:

import 'package:chrome/chrome.dart' as chrome;

and then write their code like this

chrome.app.window.current()

which will look very similar to the JavaScript usage. Let me know what you think!

@financeCoding 
