### PR TITLE
update versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,9 @@ authors:
 description: A library for accessing the chrome.* apis in a Chrome packaged app or extension.
 homepage: https://github.com/dart-gde/chrome.dart
 dependencies:
-  browser: 0.5.7
-  js: 0.0.22
-  logging: '>=0.5.7 <0.5.8'
+  browser: any
+  js: any
+  logging: any
 dev_dependencies:
-  hop: '>=0.22.1'
-  unittest: '>=0.5.7 <0.5.8'
+  hop: any
+  unittest: any


### PR DESCRIPTION
@financeCoding 

What do you think about removing the version constraints? I like using 'any' in the absence of knowing that a particular version won't work. Tightly specifying version ranges means that consumers of this library, that might need a different version, can't use them.
