### PR TITLE
added a library to reference all extension tests

### DIFF
--- a/test/harness_extension.dart
+++ b/test/harness_extension.dart
@@ -1,0 +1,59 @@
+// TODO(devoncarew): we need to create a general test harness for the extensions
+// APIs
+
+library harness_extension;
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:typed_data' as typed_data;
+
+import 'package:unittest/html_enhanced_config.dart';
+import 'package:unittest/unittest.dart';
+import 'package:logging/logging.dart';
+import 'package:js/js.dart' as js;
+
+import 'package:chrome/chrome_ext.dart';
+
+// TODO(devoncarew): we currently can't part these because they're used by the
+// harness_browser.dart library. Possibly convert the parts into libraries?
+//part 'src/test_i18n.dart';
+//part 'src/test_power.dart';
+//part 'src/test_push_messaging.dart';
+//part 'src/test_runtime.dart';
+//part 'src/test_storage.dart';
+part 'src/test_windows.dart';
+
+main() {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen((LogRecord r) {
+    StringBuffer sb = new StringBuffer();
+    sb
+    ..write(r.time.toString())
+    ..write(":")
+    ..write(r.loggerName)
+    ..write(":")
+    ..write(r.level.name)
+    ..write(":")
+    ..write(r.sequenceNumber)
+    ..write(": ")
+    ..write(r.message.toString());
+    logMessage(sb.toString());
+  });
+
+  groupSep = '.';
+  useHtmlEnhancedConfiguration();
+
+  html.window.onKeyUp.listen((html.KeyboardEvent event) {
+    if (event.keyCode == html.KeyCode.R) {
+      Runtime.reload();
+    }
+  });
+
+  // TODO: add these back in
+//  new TestI18N().main();
+//  new TestPower().main();
+//  new TestPushMessaging().main();
+//  new TestRuntime().main();
+//  new TestStorage().main();
+  new TestWindows().main();
+}

--- a/test/src/test_windows.dart
+++ b/test/src/test_windows.dart
@@ -1,73 +1,73 @@
 // TODO Figure out how we want to run extension API tests.
-// part of harness_browser;
+part of harness_extension;
 
 class TestWindows {
   void main() {
     group('chrome.windows', () {
       test('get', () {
-        var id = ext.windows.WINDOW_ID_CURRENT;
-        ext.windows.get(id)
-            .then(expectAsync1((ext.Window window) {
+        var id = windows.WINDOW_ID_CURRENT;
+        windows.get(id)
+            .then(expectAsync1((Window window) {
               expect(window.id, equals(id));
-              expect(window.state is ext.WindowState, isTrue);
-              expect(window.type is ext.WindowType, isTrue);
+              expect(window.state is WindowState, isTrue);
+              expect(window.type is WindowType, isTrue);
             }));
       });
 
       test('getCurrent', () {
-        var id = ext.windows.WINDOW_ID_CURRENT;
-        ext.windows.getCurrent()
-            .then(expectAsync1((ext.Window window) {
+        var id = windows.WINDOW_ID_CURRENT;
+        windows.getCurrent()
+            .then(expectAsync1((Window window) {
               expect(window.id, equals(id));
-              expect(window.state is ext.WindowState, isTrue);
-              expect(window.type is ext.WindowType, isTrue);
+              expect(window.state is WindowState, isTrue);
+              expect(window.type is WindowType, isTrue);
             }));
       });
 
       test('getLastFocused', () {
-        ext.windows.getLastFocused()
-            .then(expectAsync1((ext.Window window) {
-              expect(window.state is ext.WindowState, isTrue);
-              expect(window.type is ext.WindowType, isTrue);
+        windows.getLastFocused()
+            .then(expectAsync1((Window window) {
+              expect(window.state is WindowState, isTrue);
+              expect(window.type is WindowType, isTrue);
             }));
       });
 
       test('getAll', () {
-        ext.windows.getAll()
-            .then(expectAsync1((List<ext.Window> windows) {
+        windows.getAll()
+            .then(expectAsync1((List<Window> windows) {
               expect(windows.isNotEmpty, isTrue);
-              expect(windows.first.state is ext.WindowState, isTrue);
-              expect(windows.first.type is ext.WindowType, isTrue);
+              expect(windows.first.state is WindowState, isTrue);
+              expect(windows.first.type is WindowType, isTrue);
             }));
       });
 
 
       test('create', () {
-        ext.windows.create(type: ext.WindowType.NORMAL)
-            .then(expectAsync1((ext.Window window) {
-              expect(window.state is ext.WindowState, isTrue);
-              expect(window.type, ext.WindowType.NORMAL);
+        windows.create(type: WindowType.NORMAL)
+            .then(expectAsync1((Window window) {
+              expect(window.state is WindowState, isTrue);
+              expect(window.type, WindowType.NORMAL);
             }));
       });
 
       test('update', () {
-        ext.windows.create()
+        windows.create()
           .then((window) =>
-              ext.windows.update(window.id, state: ext.WindowState.MINIMIZED))
-          .then(expectAsync1((ext.Window window) {
-            expect(window.state, ext.WindowState.FULLSCREEN);
-            expect(window.type, ext.WindowType.NORMAL);
+              windows.update(window.id, state: WindowState.MINIMIZED))
+          .then(expectAsync1((Window window) {
+            expect(window.state, WindowState.FULLSCREEN);
+            expect(window.type, WindowType.NORMAL);
           }));
       });
 
       test('remove', () {
-        ext.windows.create()
-          .then((window) => ext.Windows.remove(window.id));
+        windows.create()
+          .then((window) => windows.remove(window.id));
       });
 
       test('remove', () {
-        ext.windows.create()
-          .then((window) => ext.Windows.remove(window.id));
+        windows.create()
+          .then((window) => windows.remove(window.id));
       });
     });
   }

--- a/tool/hop_runner.dart
+++ b/tool/hop_runner.dart
@@ -30,7 +30,7 @@ void main() {
       ['lib/chrome.dart', 'lib/chrome_ext.dart']));
 
   addTask('analyze_tests', createAnalyzerTask(
-      ['test/harness_browser.dart']));
+      ['test/harness_browser.dart', 'test/harness_extension.dart']));
 
   addTask('analyze_examples', createAnalyzerTask(
       ['example/serial_clock/web/clock.dart',


### PR DESCRIPTION
This adds a library to reference the extension tests, and add the test_windows.dart file to that library. This lets the references in that file be analyzed correctly. Actually running the tests can be step two :) .

@DrMarcII

@financeCoding Adam, once this lands, can you add the 'analyze_tests' hop task to the drone.io build? Thanks!
