### PR TITLE
Versioning for 0.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,14 @@
 # Changelog - chrome.dart
 
-## 0.2.0-dev
+## 0.2.0
 
 - Support for Chrome extension APIs was added.  You should now import one of the
 following libraries, as appropriate:
 	- Packaged apps: `import 'package:chrome/app.dart';`
-	- Extensions: `import 'package:chrome/ext.dart';`	
+	- Extensions: `import 'package:chrome/ext.dart';`
 - Work on the `chrome.app.window` API including several breaking changes, please
 refer to the dartdoc for usage.
+- Added identity support and example
 
 ## 0.0.1 20 May 2013 (SDK 0.5.9.0 r22879)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,14 @@
 name: chrome
-version: 0.2.0-dev
+version: 0.2.0
 authors:
 - Adam Singer <financeCoding@gmail.com>
 - Kevin Moore <kevin@thinkpixellab.com>
 - Devon Carew <devoncarew@gmail.com>
 description: A library for accessing the chrome.* apis in a Chrome packaged app or extension.
 homepage: https://github.com/dart-gde/chrome.dart
-dependencies:  
+environment:
+  sdk: '>=0.6.15'
+dependencies:
   js: any
   logging: any
 dev_dependencies:


### PR DESCRIPTION
```
## 0.2.0

- Support for Chrome extension APIs was added.  You should now import one of the
following libraries, as appropriate:
    - Packaged apps: `import 'package:chrome/app.dart';`
    - Extensions: `import 'package:chrome/ext.dart';`
- Work on the `chrome.app.window` API including several breaking changes, please
refer to the dartdoc for usage.
- Added identity support and example
```
