### PR TITLE
re-work the fileSystem library

### DIFF
--- a/bin/hop
+++ b/bin/hop
@@ -5,7 +5,6 @@ cmd="dart
 --warning_as_error
 --enable_type_checks
 --enable_asserts
---error_on_malformed_type
 --package-root=$PACK_DIR
 ./tool/hop_runner.dart $@"
 exec $cmd

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -54,8 +54,8 @@ dynamic listify(js.Proxy jsArray) {
 }
 
 /**
- * An object for handling completion callbacks that are common in the
- * chrome.* APIs.
+ * An object for handling completion callbacks that are common in the chrome.*
+ * APIs.
  */
 class ChromeCompleter<T> {
   final Completer<T> _completer = new Completer();

--- a/lib/src/debugger.dart
+++ b/lib/src/debugger.dart
@@ -1,6 +1,7 @@
 library chrome.debugger;
 
 import 'dart:async';
+
 import 'package:js/js.dart' as js;
 import 'package:js/js_wrapping.dart' as jsw;
 

--- a/lib/src/file_system.dart
+++ b/lib/src/file_system.dart
@@ -1,143 +1,180 @@
 library chrome.file_system;
 
 import 'dart:async';
+import 'dart:html';
+import 'dart:typed_data';
 
 import 'package:js/js.dart' as js;
+import 'package:meta/meta.dart';
 
 import 'common.dart';
 
-final ChromeFileSystem fileSystem  = new ChromeFileSystem();
+/// Accessor for the `chrome.fileSystem` namespace.
+final ChromeFileSystem fileSystem  = new ChromeFileSystem._();
 
-// chrome.fileSystem
-
-// Examples here:
-//   http://developer.chrome.com/apps/app_storage.html
-//   http://www.html5rocks.com/en/tutorials/file/filesystem/
-
-// chrome.fileSystem docs here:
-//   http://developer.chrome.com/dev/apps/fileSystem.html
-
-// FileEntry interface definition:
-//   http://www.w3.org/TR/file-system-api/#the-fileentry-interface
-//   http://dev.w3.org/2006/webapi/FileAPI/
-
-//interface File : Blob {
-//  readonly attribute DOMString name;
-//  readonly attribute Date lastModifiedDate;
-//};
-
-//interface FileEntry : Entry {
-//    void createWriter (FileWriterCallback successCallback, optional ErrorCallback errorCallback);
-//    void file (FileCallback successCallback, optional ErrorCallback errorCallback);
-//};
-
-//interface FileCallback {
-//    void handleEvent (File file);
-//};
-
-//interface FileWriterCallback {
-//    void handleEvent (FileWriter fileWriter);
-//};
-
-//interface ErrorCallback {
-//    void handleEvent (DOMError err);
-//};
-
+/**
+ * Use the chrome.fileSystem API to create, read, navigate, and write to a
+ * sandboxed section of the user's local file system. With this API, packaged
+ * apps can read and write to a user-selected location. For example, a text
+ * editor app can use the API to read and write local documents.
+ */
 class ChromeFileSystem {
 
-  Future<ChromeFileEntry> chooseOpenFile() {
-    Completer completer = new Completer();
+  ChromeFileSystem._();
 
-    js.scoped(() {
-      js.Callback callback = new js.Callback.once((var fileEntry) {
-        if (fileEntry != null) {
-          completer.complete(new ChromeFileEntry(fileEntry));
-        } else {
-          completer.complete(null);
-        }
-      });
-
-      chromeProxy.fileSystem.chooseEntry(js.map({'type': 'openFile'}), callback);
-    });
-
-    return completer.future;
-  }
-
-  Future<ChromeFileEntry> chooseSaveFile() {
-    Completer completer = new Completer();
-
-    js.scoped(() {
-      js.Callback callback = new js.Callback.once((var fileEntry) {
-        if (fileEntry != null) {
-          completer.complete(new ChromeFileEntry(fileEntry));
-        } else {
-          completer.complete(null);
-        }
-      });
-
-      chromeProxy.fileSystem.chooseEntry(js.map({'type': 'saveFile'}), callback);
-    });
-
-    return completer.future;
-  }
+  dynamic get _fileSystem => (js.context as dynamic).chrome.fileSystem;
 
   /**
    * Get the display path of a FileEntry object. The display path is based on
    * the full path of the file on the local file system, but may be made more
    * readable for display purposes.
    */
-  Future<String> getDisplayPath(ChromeFileEntry fileEntry) {
-    return js.scoped(() {
-      Completer completer = new Completer();
+  Future<String> getDisplayPath(FileEntry fileEntry) {
+    ChromeCompleter<String> completer = new ChromeCompleter.oneArg();
+    _fileSystem.getDisplayPath(fileEntry, completer.callback);
+    return completer.future;
+  }
 
-      js.Callback callback = new js.Callback.once((var path) {
-        completer.complete(path);
-      });
-
-      chromeProxy.fileSystem.getDisplayPath(fileEntry._proxy, callback);
-
-      return completer.future;
-    });
+  /**
+   * Get a writable FileEntry from another FileEntry. This call will fail if the
+   * application does not have the 'write' permission under 'fileSystem'.
+   *
+   * Note that this will soon be deprecated.
+   */
+  @deprecated
+  Future<FileEntry> getWritableEntry(FileEntry fileEntry) {
+    ChromeCompleter<FileEntry> completer = new ChromeCompleter.oneArg();
+    _fileSystem.getWritableEntry(fileEntry, completer.callback);
+    return completer.future;
   }
 
   /**
    * Gets whether this FileEntry is writable or not.
+   *
+   * Note that this will soon be deprecated.
    */
-  Future<bool> isWritableEntry(ChromeFileEntry fileEntry) {
-    return js.scoped(() {
-      Completer completer = new Completer();
-
-      js.Callback callback = new js.Callback.once((var writeable) {
-        completer.complete(writeable);
-      });
-
-      chromeProxy.fileSystem.isWritableEntry(fileEntry._proxy, callback);
-
-      return completer.future;
-    });
+  @deprecated
+  Future<bool> isWritableEntry(FileEntry fileEntry) {
+    ChromeCompleter<bool> completer = new ChromeCompleter.oneArg();
+    _fileSystem.isWritableEntry(fileEntry, completer.callback);
+    return completer.future;
   }
 
   /**
-   * Returns the file entry with the given id.
+   * Ask the user to choose a file.
+   *
+   * [type] is one of 'openFile', 'openWritableFile', 'saveFile'. Note that
+   * 'openWritableFile' will soon be deprecated.
    */
-  ChromeFileEntry getEntryById(String id) {
-    return js.scoped(() {
-      return new ChromeFileEntry(chromeProxy.fileSystem.getEntryById(id));
-    });
+  Future<FileEntry> chooseEntry({
+    String type: 'openFile',
+    String suggestedName,
+    List<ChooseEntryAccepts> accepts,
+    bool acceptsAllTypes: true}) {
+
+    Map<String, dynamic> options = {};
+    if (type != null) options['type'] = type;
+    if (suggestedName != null) options['suggestedName'] = suggestedName;
+    if (accepts != null) options['openFile'] = js.array(accepts);
+    if (acceptsAllTypes != null) options['acceptsAllTypes'] = acceptsAllTypes;
+
+    ChromeCompleter<FileEntry> completer = new ChromeCompleter.twoArgs(
+        (fileEntry, fileEntries) => fileEntry);
+    _fileSystem.chooseEntry(js.map(options), completer.callback);
+    return completer.future;
   }
 
   /**
-   * Returns the id of the given file entry. This can be used to retrieve file
-   * entries with getEntryById(). When an app is restarted (ie: it is sent the
-   * onRestarted event) it can regain access to the file entries it had by
-   * remembering their ids and calling getEntryById().
+   * Ask the user to choose (open) a directory. This is sugar for the
+   * chrome.fileSystem.chooseEntry call.
    */
-  String getEntryId(ChromeFileEntry fileEntry) {
-    return js.scoped(() {
-      return chromeProxy.fileSystem.getEntryId(fileEntry._proxy);
+  Future<DirectoryEntry> chooseEntryDirectory({
+    String suggestedName,
+    List<ChooseEntryAccepts> accepts,
+    bool acceptsAllTypes: true}) {
+
+    Map<String, dynamic> options = {};
+    options['type'] = 'openDirectory';
+    if (suggestedName != null) options['suggestedName'] = suggestedName;
+    if (accepts != null) options['openFile'] = js.array(accepts);
+    if (acceptsAllTypes != null) options['acceptsAllTypes'] = acceptsAllTypes;
+
+    ChromeCompleter<DirectoryEntry> completer = new ChromeCompleter.twoArgs(
+        (fileEntry, fileEntries) => fileEntry);
+    _fileSystem.chooseEntry(js.map(options), completer.callback);
+    return completer.future;
+  }
+
+  /**
+   * Ask the user to choose one or more files. This is sugar for the
+   * chrome.fileSystem.chooseEntry call.
+   *
+   * [type] is one of "openFile", "openWritableFile", or "saveFile"
+   */
+  Future<List<FileEntry>> chooseEntries({
+    String type: 'openFile',
+    String suggestedName,
+    List<ChooseEntryAccepts> accepts,
+    bool acceptsAllTypes: true}) {
+
+    Map<String, dynamic> options = {};
+    if (type != null) options['type'] = type;
+    if (suggestedName != null) options['suggestedName'] = suggestedName;
+    if (accepts != null) options['openFile'] = js.array(accepts);
+    if (acceptsAllTypes != null) options['acceptsAllTypes'] = acceptsAllTypes;
+    options['acceptsMultiple'] = true;
+
+    ChromeCompleter<List<FileEntry>> completer = new ChromeCompleter.twoArgs((fileEntry, fileEntries) {
+      if (fileEntries != null) {
+        return fileEntries;
+      } else if (fileEntry != null) {
+        return [fileEntry];
+      } else {
+        return null;
+      }
     });
+    _fileSystem.chooseEntry(js.map(options), completer.callback);
+    return completer.future;
+  }
+
+  /**
+   * Returns the file entry with the given id if it can be restored. This call
+   * will fail otherwise. This method is new in Chrome 30.
+   */
+  Future<FileEntry> restoreEntry(String id) {
+    ChromeCompleter<FileEntry> completer = new ChromeCompleter.oneArg();
+    _fileSystem.restoreEntry(id, completer.callback);
+    return completer.future;
+  }
+
+  /**
+   * Returns whether a file entry for the given id can be restored, i.e. whether
+   * restoreEntry would succeed with this id now. This method is new in Chrome
+   * 30.
+   */
+  Future<bool> isRestorable(String id) {
+    ChromeCompleter<bool> completer = new ChromeCompleter.oneArg();
+    _fileSystem.isRestorable(id, completer.callback);
+    return completer.future;
+  }
+
+  /**
+   * Returns an id that can be passed to restoreEntry to regain access to a
+   * given file entry. Only the 500 most recently used entries are retained,
+   * where calls to retainEntry and restoreEntry count as use. If the app has
+   * the 'retainEntries' permission under 'fileSystem' (currently restricted to
+   * dev channel), entries are retained indefinitely. Otherwise, entries are
+   * retained only while the app is running and across restarts. This method is
+   * new in Chrome 30.
+   */
+  String retainEntry(FileEntry fileEntry) {
+    return _fileSystem.retainEntry(fileEntry);
   }
 }
+
+// FileEntry interface definition:
+//   http://www.w3.org/TR/file-system-api/#the-fileentry-interface
+//   http://dev.w3.org/2006/webapi/FileAPI/
 
 //interface Entry {
 //    readonly attribute boolean    isFile;
@@ -153,139 +190,99 @@ class ChromeFileSystem {
 //    void      getParent (EntryCallback successCallback, optional ErrorCallback errorCallback);
 //};
 
-//file id = 338AA34D90FC449DABB1249355C96C7F:solar.html undefined:1
-//file name = solar.html undefined:1
-//file fullPath = /solar.html undefined:1
-//file toURL = undefined:1
-//display path = ~/Google Drive/scratch/solar/web/solar.html
+/*
+ * Utility methods for dealing with FileEntries (not strictly part of the chrome
+ * app API).
+ */
 
-class ChromeFileEntry {
-  js.Proxy _proxy;
-
-  String _name;
-  String _fullPath;
-  bool _isFile;
-  bool _isDirectory;
-
-  ChromeFileEntry(js.Proxy proxy) {
-    this._proxy = proxy;
-
-    js.retain(_proxy);
-
-    _name = _proxy.name;
-    _fullPath = _proxy.fullPath;
-    _isFile = _proxy.isFile;
-    _isDirectory = _proxy.isDirectory;
-  }
-
-  String get name => _name;
-
-  String toString() => name;
-
-  String get fullPath => _fullPath;
-
-  String get id => fileSystem.getEntryId(this);
-
-  String toURL() {
-    return js.scoped(() {
-      return _proxy.toURL();
-    });
-  }
-
-  // TODO: this seems to crash Dartium consistently -
-  Future<ChromeFileEntry> getParent() {
-    return js.scoped(() {
-      Completer completer = new Completer();
-
-      _proxy.getParent(
-          new js.Callback.once((var e) {
-            completer.complete(new ChromeFileEntry(e));
-          }),
-          new js.Callback.once((var e) {
-            completer.completeError(e);
-          })
-      );
-
-      return completer.future;
-    });
-  }
-
-  Future<String> readContents() {
-//    readOnlyEntry.file(function(file) {
-//      var reader = new FileReader();
-//
-//      reader.onerror = errorHandler;
-//      reader.onloadend = function(e) {
-//        console.log(e.target.result);
-//      };
-//
-//      reader.readAsText(file);
-//    });
-
-    Completer completer = new Completer();
-
-    js.scoped(() {
-      js.Callback contentsCallback = new js.Callback.once((var e) {
-        // TODO:
-        completer.complete(e.target.result);
-      });
-
-      js.Callback callback = new js.Callback.once((var file) {
-        var reader = new js.Proxy(js.context.FileReader);
-        (reader as dynamic).onloadend = contentsCallback;
-        (reader as dynamic).readAsText(file);
-      });
-
-      _proxy.file(callback);
-    });
-
+/**
+ * A conveinence method to read data from a dom [FileEntry]. The file contents
+ * are returned as text.
+ *
+ * Errors will come back through the Future as [FileError].
+ */
+Future<String> fileEntryRead(FileEntry fileEntry, [String encoding]) {
+  return fileEntry.file().then((File file) {
+    Completer<String> completer = new Completer();
+    FileReader reader = new FileReader();
+    reader.onLoadEnd.listen((_) => completer.complete(reader.result));
+    reader.onError.listen((_) => completer.completeError(reader.error));
+    if (encoding == null) {
+      reader.readAsText(file);
+    } else {
+      reader.readAsText(file, encoding);
+    }
     return completer.future;
-  }
+  });
+}
 
-  Future<ChromeFileEntry> writeContents(String contents) {
-//  chrome.fileSystem.getWritableEntry(chosenFileEntry, function(writableEntry)
-
-//  writableFileEntry.createWriter(function(writer) {
-//    writer.onerror = errorHandler;
-//    writer.onwriteend = function(e) {
-//      console.log('write complete');
-//    };
-//    writer.write(new Blob(['1234567890'], {type: 'text/plain'}));
-//  }, errorHandler);
-
-    Completer completer = new Completer();
-
-    js.scoped(() {
-      js.Callback writeEndCallback = new js.Callback.once((var event) {
-        if (!completer.isCompleted) {
-          completer.complete(this);
-        }
-      });
-
-      js.Callback errorCallback = new js.Callback.once((var event) {
-        completer.completeError(event);
-      });
-
-      js.Callback writerCallback = new js.Callback.once((var writer) {
-        // blob = new Blob([contents])
-        var blob = new js.Proxy(js.context.Blob, js.array([contents]));
-
-        writer.onwriteend = writeEndCallback;
-        writer.onerror = errorCallback;
-        writer.write(blob, js.map({'type': 'text/plain'}));
-      });
-
-      js.Callback writeableCallback = new js.Callback.once((var writeableEntry) {
-        writeableEntry.createWriter(writerCallback, errorCallback);
-      });
-
-      chromeProxy.fileSystem.getWritableEntry(_proxy, writeableCallback);
-    });
-
+/**
+ * A conveinence method to read data from a dom [FileEntry]. The file contents
+ * are returned as binary (a list of ints).
+ *
+ * Errors will come back through the Future as [FileError].
+ */
+Future<List<int>> fileEntryReadBinary(FileEntry fileEntry) {
+  return fileEntry.file().then((File file) {
+    Completer<List<int>> completer = new Completer();
+    FileReader reader = new FileReader();
+    reader.onLoadEnd.listen((_) => completer.complete(new Uint8List.view(reader.result)));
+    reader.onError.listen((_) => completer.completeError(reader.error));
+    reader.readAsArrayBuffer(file);
     return completer.future;
-  }
+  });
+}
 
-  void dispose() {
-    js.release(_proxy);
+/**
+ * A conveinence method to write text to a dom [FileEntry]. On success, the same
+ * [FileEntry] is returned from the Future.
+ *
+ * Errors will come back through the Future as [FileError].
+ */
+Future<FileEntry> fileEntryWrite(FileEntry fileEntry, String text) {
+  return fileEntry.createWriter().then((FileWriter writer) {
+    Completer<FileEntry> completer = new Completer();
+    writer.onWriteEnd.listen((_) => completer.complete(fileEntry));
+    writer.onError.listen((_) => completer.completeError(writer.error));
+    writer.write(new Blob([text]));
+    return completer.future;
+  });
+}
+
+
+/**
+ * For use in the [ChromeFileSystem.chooseEntry] and
+ * [ChromeFileSystem.chooseEntry] methods.
+ */
+class ChooseEntryAccepts implements js.Serializable {
+  /**
+   * This is the optional text description for this option. If not present, a
+   * description will be automatically generated; typically containing an
+   * expanded list of valid extensions (e.g. "text/html" may expand to "*.html,
+   * *.htm").
+   */
+  String description;
+
+  /**
+   * Mime-types to accept, e.g. "image/jpeg" or "audio/ *". One of mimeTypes or
+   * extensions must contain at least one valid element.
+   */
+  List<String> mimeTypes;
+
+  /**
+   * Extensions to accept, e.g. "jpg", "gif", "crx".
+   */
+  List<String> extensions;
+
+  ChooseEntryAccepts({this.description, this.mimeTypes, this.extensions});
+
+  dynamic toJs() {
+    Map m = {};
+
+    if (description != null) m['description'] = description;
+    if (mimeTypes != null) m['mimeTypes'] = mimeTypes;
+    if (extensions != null) m['extensions'] = extensions;
+
+    return js.map(m);
   }
 }

--- a/lib/src/tabs.dart
+++ b/lib/src/tabs.dart
@@ -34,7 +34,7 @@ class Tabs {
    */
   Future<Tab> getCurrent() {
     var completer =
-        new ChromeCompleter. oneArg((tab) => new Tab(tab));
+        new ChromeCompleter.oneArg((tab) => new Tab(tab));
     js.scoped(() {
       _tabs.getCurrent(completer.callback);
     });


### PR DESCRIPTION
This CL is a re-write of the chrome.file_system library. This maps much more closely to the actual chrome.fileSystem API; the previous version was essentially just what I needed for my chrome app. There are some non-API utility methods in here to make it easier to get content into and out of files. Any other thoughts on where this should live are appreciated. I think that in general we'll want some higher level interface to some of the APIs. I.e. map closly to the chrome app APIs, but add some abstractions on top to make them easier to use.

The fileSystem API is difficult to test - getting a FileEntry requires a user action. I'm planning on adding a new example into the example/ directory, with a button to get a file entry and then run through tests. Thoughts welcome!
