### PR TITLE
Use a getter to fetch the JsObject for an API each time it is needed

### DIFF
--- a/lib/gen/alarms.dart
+++ b/lib/gen/alarms.dart
@@ -14,9 +14,16 @@ import '../src/common.dart';
 final ChromeAlarms alarms = new ChromeAlarms._();
 
 class ChromeAlarms extends ChromeApi {
-  static final JsObject _alarms = chrome['alarms'];
+  JsObject get _alarms => chrome['alarms'];
 
-  ChromeAlarms._();
+  Stream<Alarm> get onAlarm => _onAlarm.stream;
+  ChromeStreamController<Alarm> _onAlarm;
+
+  ChromeAlarms._() {
+    var getApi = () => _alarms;
+    _onAlarm =
+        new ChromeStreamController<Alarm>.oneArg(getApi, 'onAlarm', _createAlarm);
+  }
 
   bool get available => _alarms != null;
 
@@ -91,11 +98,6 @@ class ChromeAlarms extends ChromeApi {
 
     _alarms.callMethod('clearAll');
   }
-
-  Stream<Alarm> get onAlarm => _onAlarm.stream;
-
-  final ChromeStreamController<Alarm> _onAlarm =
-      new ChromeStreamController<Alarm>.oneArg(_alarms, 'onAlarm', _createAlarm);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.alarms' is not available");

--- a/lib/gen/app.dart
+++ b/lib/gen/app.dart
@@ -30,21 +30,23 @@ class ChromeApp {
  * at anytime.
  */
 class ChromeAppRuntime extends ChromeApi {
-  static final JsObject _app_runtime = chrome['app']['runtime'];
-
-  ChromeAppRuntime._();
-
-  bool get available => _app_runtime != null;
+  JsObject get _app_runtime => chrome['app']['runtime'];
 
   Stream<LaunchData> get onLaunched => _onLaunched.stream;
-
-  final ChromeStreamController<LaunchData> _onLaunched =
-      new ChromeStreamController<LaunchData>.oneArg(_app_runtime, 'onLaunched', _createLaunchData);
+  ChromeStreamController<LaunchData> _onLaunched;
 
   Stream get onRestarted => _onRestarted.stream;
+  ChromeStreamController _onRestarted;
 
-  final ChromeStreamController _onRestarted =
-      new ChromeStreamController.noArgs(_app_runtime, 'onRestarted');
+  ChromeAppRuntime._() {
+    var getApi = () => _app_runtime;
+    _onLaunched =
+        new ChromeStreamController<LaunchData>.oneArg(getApi, 'onLaunched', _createLaunchData);
+    _onRestarted =
+        new ChromeStreamController.noArgs(getApi, 'onRestarted');
+  }
+
+  bool get available => _app_runtime != null;
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.app.runtime' is not available");
@@ -105,9 +107,41 @@ LaunchItem _createLaunchItem(JsObject jsProxy) => jsProxy == null ? null : new L
  * Chrome browser windows.
  */
 class _ChromeAppWindow extends ChromeApi {
-  static final JsObject _app_window = chrome['app']['window'];
+  JsObject get _app_window => chrome['app']['window'];
 
-  _ChromeAppWindow._();
+  Stream get onBoundsChanged => _onBoundsChanged.stream;
+  ChromeStreamController _onBoundsChanged;
+
+  Stream get onClosed => _onClosed.stream;
+  ChromeStreamController _onClosed;
+
+  Stream get onFullscreened => _onFullscreened.stream;
+  ChromeStreamController _onFullscreened;
+
+  Stream get onMaximized => _onMaximized.stream;
+  ChromeStreamController _onMaximized;
+
+  Stream get onMinimized => _onMinimized.stream;
+  ChromeStreamController _onMinimized;
+
+  Stream get onRestored => _onRestored.stream;
+  ChromeStreamController _onRestored;
+
+  _ChromeAppWindow._() {
+    var getApi = () => _app_window;
+    _onBoundsChanged =
+        new ChromeStreamController.noArgs(getApi, 'onBoundsChanged');
+    _onClosed =
+        new ChromeStreamController.noArgs(getApi, 'onClosed');
+    _onFullscreened =
+        new ChromeStreamController.noArgs(getApi, 'onFullscreened');
+    _onMaximized =
+        new ChromeStreamController.noArgs(getApi, 'onMaximized');
+    _onMinimized =
+        new ChromeStreamController.noArgs(getApi, 'onMinimized');
+    _onRestored =
+        new ChromeStreamController.noArgs(getApi, 'onRestored');
+  }
 
   bool get available => _app_window != null;
 
@@ -165,36 +199,6 @@ class _ChromeAppWindow extends ChromeApi {
 
     _app_window.callMethod('initializeAppWindow', [jsify(state)]);
   }
-
-  Stream get onBoundsChanged => _onBoundsChanged.stream;
-
-  final ChromeStreamController _onBoundsChanged =
-      new ChromeStreamController.noArgs(_app_window, 'onBoundsChanged');
-
-  Stream get onClosed => _onClosed.stream;
-
-  final ChromeStreamController _onClosed =
-      new ChromeStreamController.noArgs(_app_window, 'onClosed');
-
-  Stream get onFullscreened => _onFullscreened.stream;
-
-  final ChromeStreamController _onFullscreened =
-      new ChromeStreamController.noArgs(_app_window, 'onFullscreened');
-
-  Stream get onMaximized => _onMaximized.stream;
-
-  final ChromeStreamController _onMaximized =
-      new ChromeStreamController.noArgs(_app_window, 'onMaximized');
-
-  Stream get onMinimized => _onMinimized.stream;
-
-  final ChromeStreamController _onMinimized =
-      new ChromeStreamController.noArgs(_app_window, 'onMinimized');
-
-  Stream get onRestored => _onRestored.stream;
-
-  final ChromeStreamController _onRestored =
-      new ChromeStreamController.noArgs(_app_window, 'onRestored');
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.app.window' is not available");

--- a/lib/gen/audio.dart
+++ b/lib/gen/audio.dart
@@ -15,9 +15,16 @@ import '../src/common.dart';
 final ChromeAudio audio = new ChromeAudio._();
 
 class ChromeAudio extends ChromeApi {
-  static final JsObject _audio = chrome['audio'];
+  JsObject get _audio => chrome['audio'];
 
-  ChromeAudio._();
+  Stream get onDeviceChanged => _onDeviceChanged.stream;
+  ChromeStreamController _onDeviceChanged;
+
+  ChromeAudio._() {
+    var getApi = () => _audio;
+    _onDeviceChanged =
+        new ChromeStreamController.noArgs(getApi, 'onDeviceChanged');
+  }
 
   bool get available => _audio != null;
 
@@ -57,11 +64,6 @@ class ChromeAudio extends ChromeApi {
     _audio.callMethod('setProperties', [id, jsify(properties), completer.callback]);
     return completer.future;
   }
-
-  Stream get onDeviceChanged => _onDeviceChanged.stream;
-
-  final ChromeStreamController _onDeviceChanged =
-      new ChromeStreamController.noArgs(_audio, 'onDeviceChanged');
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.audio' is not available");

--- a/lib/gen/bluetooth.dart
+++ b/lib/gen/bluetooth.dart
@@ -13,9 +13,21 @@ import '../src/common.dart';
 final ChromeBluetooth bluetooth = new ChromeBluetooth._();
 
 class ChromeBluetooth extends ChromeApi {
-  static final JsObject _bluetooth = chrome['bluetooth'];
+  JsObject get _bluetooth => chrome['bluetooth'];
 
-  ChromeBluetooth._();
+  Stream<AdapterState> get onAdapterStateChanged => _onAdapterStateChanged.stream;
+  ChromeStreamController<AdapterState> _onAdapterStateChanged;
+
+  Stream<Socket> get onConnection => _onConnection.stream;
+  ChromeStreamController<Socket> _onConnection;
+
+  ChromeBluetooth._() {
+    var getApi = () => _bluetooth;
+    _onAdapterStateChanged =
+        new ChromeStreamController<AdapterState>.oneArg(getApi, 'onAdapterStateChanged', _createAdapterState);
+    _onConnection =
+        new ChromeStreamController<Socket>.oneArg(getApi, 'onConnection', _createSocket);
+  }
 
   bool get available => _bluetooth != null;
 
@@ -201,16 +213,6 @@ class ChromeBluetooth extends ChromeApi {
     _bluetooth.callMethod('stopDiscovery', [completer.callback]);
     return completer.future;
   }
-
-  Stream<AdapterState> get onAdapterStateChanged => _onAdapterStateChanged.stream;
-
-  final ChromeStreamController<AdapterState> _onAdapterStateChanged =
-      new ChromeStreamController<AdapterState>.oneArg(_bluetooth, 'onAdapterStateChanged', _createAdapterState);
-
-  Stream<Socket> get onConnection => _onConnection.stream;
-
-  final ChromeStreamController<Socket> _onConnection =
-      new ChromeStreamController<Socket>.oneArg(_bluetooth, 'onConnection', _createSocket);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.bluetooth' is not available");
@@ -488,10 +490,10 @@ class StartDiscoveryOptions extends ChromeObject {
 }
 
 AdapterState _createAdapterState(JsObject jsProxy) => jsProxy == null ? null : new AdapterState.fromProxy(jsProxy);
+Socket _createSocket(JsObject jsProxy) => jsProxy == null ? null : new Socket.fromProxy(jsProxy);
 Profile _createProfile(JsObject jsProxy) => jsProxy == null ? null : new Profile.fromProxy(jsProxy);
 ServiceRecord _createServiceRecord(JsObject jsProxy) => jsProxy == null ? null : new ServiceRecord.fromProxy(jsProxy);
 ArrayBuffer _createArrayBuffer(/*JsObject*/ jsProxy) => jsProxy == null ? null : new ArrayBuffer.fromProxy(jsProxy);
 OutOfBandPairingData _createOutOfBandPairingData(JsObject jsProxy) => jsProxy == null ? null : new OutOfBandPairingData.fromProxy(jsProxy);
-Socket _createSocket(JsObject jsProxy) => jsProxy == null ? null : new Socket.fromProxy(jsProxy);
 BluetoothDevice _createDevice(JsObject jsProxy) => jsProxy == null ? null : new BluetoothDevice.fromProxy(jsProxy);
 DeviceCallback _createDeviceCallback(JsObject jsProxy) => jsProxy == null ? null : new DeviceCallback.fromProxy(jsProxy);

--- a/lib/gen/browser_action.dart
+++ b/lib/gen/browser_action.dart
@@ -17,9 +17,20 @@ import '../src/common.dart';
 final ChromeBrowserAction browserAction = new ChromeBrowserAction._();
 
 class ChromeBrowserAction extends ChromeApi {
-  static final JsObject _browserAction = chrome['browserAction'];
+  JsObject get _browserAction => chrome['browserAction'];
 
-  ChromeBrowserAction._();
+  /**
+   * Fired when a browser action icon is clicked.  This event will not fire if
+   * the browser action has a popup.
+   */
+  Stream<Tab> get onClicked => _onClicked.stream;
+  ChromeStreamController<Tab> _onClicked;
+
+  ChromeBrowserAction._() {
+    var getApi = () => _browserAction;
+    _onClicked =
+        new ChromeStreamController<Tab>.oneArg(getApi, 'onClicked', _createTab);
+  }
 
   bool get available => _browserAction != null;
 
@@ -158,15 +169,6 @@ class ChromeBrowserAction extends ChromeApi {
     _browserAction.callMethod('openPopup', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a browser action icon is clicked.  This event will not fire if
-   * the browser action has a popup.
-   */
-  Stream<Tab> get onClicked => _onClicked.stream;
-
-  final ChromeStreamController<Tab> _onClicked =
-      new ChromeStreamController<Tab>.oneArg(_browserAction, 'onClicked', _createTab);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.browserAction' is not available");
@@ -373,5 +375,5 @@ class BrowserActionGetBadgeBackgroundColorParams extends ChromeObject {
   set tabId(int value) => jsProxy['tabId'] = value;
 }
 
-ColorArray _createColorArray(JsObject jsProxy) => jsProxy == null ? null : new ColorArray.fromProxy(jsProxy);
 Tab _createTab(JsObject jsProxy) => jsProxy == null ? null : new Tab.fromProxy(jsProxy);
+ColorArray _createColorArray(JsObject jsProxy) => jsProxy == null ? null : new ColorArray.fromProxy(jsProxy);

--- a/lib/gen/browsing_data.dart
+++ b/lib/gen/browsing_data.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromeBrowsingData browsingData = new ChromeBrowsingData._();
 
 class ChromeBrowsingData extends ChromeApi {
-  static final JsObject _browsingData = chrome['browsingData'];
+  JsObject get _browsingData => chrome['browsingData'];
 
   ChromeBrowsingData._();
 

--- a/lib/gen/commands.dart
+++ b/lib/gen/commands.dart
@@ -15,9 +15,19 @@ import '../src/common.dart';
 final ChromeCommands commands = new ChromeCommands._();
 
 class ChromeCommands extends ChromeApi {
-  static final JsObject _commands = chrome['commands'];
+  JsObject get _commands => chrome['commands'];
 
-  ChromeCommands._();
+  /**
+   * Fired when a registered command is activated using a keyboard shortcut.
+   */
+  Stream<String> get onCommand => _onCommand.stream;
+  ChromeStreamController<String> _onCommand;
+
+  ChromeCommands._() {
+    var getApi = () => _commands;
+    _onCommand =
+        new ChromeStreamController<String>.oneArg(getApi, 'onCommand', selfConverter);
+  }
 
   bool get available => _commands != null;
 
@@ -32,14 +42,6 @@ class ChromeCommands extends ChromeApi {
     _commands.callMethod('getAll', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a registered command is activated using a keyboard shortcut.
-   */
-  Stream<String> get onCommand => _onCommand.stream;
-
-  final ChromeStreamController<String> _onCommand =
-      new ChromeStreamController<String>.oneArg(_commands, 'onCommand', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.commands' is not available");

--- a/lib/gen/content_settings.dart
+++ b/lib/gen/content_settings.dart
@@ -16,7 +16,7 @@ import '../src/common.dart';
 final ChromeContentSettings contentSettings = new ChromeContentSettings._();
 
 class ChromeContentSettings extends ChromeApi {
-  static final JsObject _contentSettings = chrome['contentSettings'];
+  JsObject get _contentSettings => chrome['contentSettings'];
 
   ChromeContentSettings._();
 

--- a/lib/gen/context_menus.dart
+++ b/lib/gen/context_menus.dart
@@ -16,9 +16,19 @@ import '../src/common.dart';
 final ChromeContextMenus contextMenus = new ChromeContextMenus._();
 
 class ChromeContextMenus extends ChromeApi {
-  static final JsObject _contextMenus = chrome['contextMenus'];
+  JsObject get _contextMenus => chrome['contextMenus'];
 
-  ChromeContextMenus._();
+  /**
+   * Fired when a context menu item is clicked.
+   */
+  Stream<OnClickedEvent> get onClicked => _onClicked.stream;
+  ChromeStreamController<OnClickedEvent> _onClicked;
+
+  ChromeContextMenus._() {
+    var getApi = () => _contextMenus;
+    _onClicked =
+        new ChromeStreamController<OnClickedEvent>.twoArgs(getApi, 'onClicked', _createOnClickedEvent);
+  }
 
   bool get available => _contextMenus != null;
 
@@ -79,14 +89,6 @@ class ChromeContextMenus extends ChromeApi {
     _contextMenus.callMethod('removeAll', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a context menu item is clicked.
-   */
-  Stream<OnClickedEvent> get onClicked => _onClicked.stream;
-
-  final ChromeStreamController<OnClickedEvent> _onClicked =
-      new ChromeStreamController<OnClickedEvent>.twoArgs(_contextMenus, 'onClicked', _createOnClickedEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.contextMenus' is not available");

--- a/lib/gen/declarative_content.dart
+++ b/lib/gen/declarative_content.dart
@@ -15,16 +15,18 @@ import '../src/common.dart';
 final ChromeDeclarativeContent declarativeContent = new ChromeDeclarativeContent._();
 
 class ChromeDeclarativeContent extends ChromeApi {
-  static final JsObject _declarativeContent = chrome['declarativeContent'];
-
-  ChromeDeclarativeContent._();
-
-  bool get available => _declarativeContent != null;
+  JsObject get _declarativeContent => chrome['declarativeContent'];
 
   Stream get onPageChanged => _onPageChanged.stream;
+  ChromeStreamController _onPageChanged;
 
-  final ChromeStreamController _onPageChanged =
-      new ChromeStreamController.noArgs(_declarativeContent, 'onPageChanged');
+  ChromeDeclarativeContent._() {
+    var getApi = () => _declarativeContent;
+    _onPageChanged =
+        new ChromeStreamController.noArgs(getApi, 'onPageChanged');
+  }
+
+  bool get available => _declarativeContent != null;
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.declarativeContent' is not available");

--- a/lib/gen/declarative_web_request.dart
+++ b/lib/gen/declarative_web_request.dart
@@ -18,16 +18,10 @@ import '../src/common.dart';
 final ChromeDeclarativeWebRequest declarativeWebRequest = new ChromeDeclarativeWebRequest._();
 
 class ChromeDeclarativeWebRequest extends ChromeApi {
-  static final JsObject _declarativeWebRequest = chrome['declarativeWebRequest'];
-
-  ChromeDeclarativeWebRequest._();
-
-  bool get available => _declarativeWebRequest != null;
+  JsObject get _declarativeWebRequest => chrome['declarativeWebRequest'];
 
   Stream get onRequest => _onRequest.stream;
-
-  final ChromeStreamController _onRequest =
-      new ChromeStreamController.noArgs(_declarativeWebRequest, 'onRequest');
+  ChromeStreamController _onRequest;
 
   /**
    * Fired when a message is sent via
@@ -35,9 +29,17 @@ class ChromeDeclarativeWebRequest extends ChromeApi {
    * declarative web request API.
    */
   Stream<Map> get onMessage => _onMessage.stream;
+  ChromeStreamController<Map> _onMessage;
 
-  final ChromeStreamController<Map> _onMessage =
-      new ChromeStreamController<Map>.oneArg(_declarativeWebRequest, 'onMessage', mapify);
+  ChromeDeclarativeWebRequest._() {
+    var getApi = () => _declarativeWebRequest;
+    _onRequest =
+        new ChromeStreamController.noArgs(getApi, 'onRequest');
+    _onMessage =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onMessage', mapify);
+  }
+
+  bool get available => _declarativeWebRequest != null;
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.declarativeWebRequest' is not available");

--- a/lib/gen/desktop_capture.dart
+++ b/lib/gen/desktop_capture.dart
@@ -15,7 +15,7 @@ import '../src/common.dart';
 final ChromeDesktopCapture desktopCapture = new ChromeDesktopCapture._();
 
 class ChromeDesktopCapture extends ChromeApi {
-  static final JsObject _desktopCapture = chrome['desktopCapture'];
+  JsObject get _desktopCapture => chrome['desktopCapture'];
 
   ChromeDesktopCapture._();
 

--- a/lib/gen/devtools.dart
+++ b/lib/gen/devtools.dart
@@ -32,9 +32,28 @@ class ChromeDevtools {
  * resources within the page.
  */
 class ChromeDevtoolsInspectedWindow extends ChromeApi {
-  static final JsObject _devtools_inspectedWindow = chrome['devtools']['inspectedWindow'];
+  JsObject get _devtools_inspectedWindow => chrome['devtools']['inspectedWindow'];
 
-  ChromeDevtoolsInspectedWindow._();
+  /**
+   * Fired when a new resource is added to the inspected page.
+   */
+  Stream<Resource> get onResourceAdded => _onResourceAdded.stream;
+  ChromeStreamController<Resource> _onResourceAdded;
+
+  /**
+   * Fired when a new revision of the resource is committed (e.g. user saves an
+   * edited version of the resource in the Developer Tools).
+   */
+  Stream<OnResourceContentCommittedEvent> get onResourceContentCommitted => _onResourceContentCommitted.stream;
+  ChromeStreamController<OnResourceContentCommittedEvent> _onResourceContentCommitted;
+
+  ChromeDevtoolsInspectedWindow._() {
+    var getApi = () => _devtools_inspectedWindow;
+    _onResourceAdded =
+        new ChromeStreamController<Resource>.oneArg(getApi, 'onResourceAdded', _createResource);
+    _onResourceContentCommitted =
+        new ChromeStreamController<OnResourceContentCommittedEvent>.twoArgs(getApi, 'onResourceContentCommitted', _createOnResourceContentCommittedEvent);
+  }
 
   bool get available => _devtools_inspectedWindow != null;
 
@@ -86,23 +105,6 @@ class ChromeDevtoolsInspectedWindow extends ChromeApi {
     _devtools_inspectedWindow.callMethod('getResources', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a new resource is added to the inspected page.
-   */
-  Stream<Resource> get onResourceAdded => _onResourceAdded.stream;
-
-  final ChromeStreamController<Resource> _onResourceAdded =
-      new ChromeStreamController<Resource>.oneArg(_devtools_inspectedWindow, 'onResourceAdded', _createResource);
-
-  /**
-   * Fired when a new revision of the resource is committed (e.g. user saves an
-   * edited version of the resource in the Developer Tools).
-   */
-  Stream<OnResourceContentCommittedEvent> get onResourceContentCommitted => _onResourceContentCommitted.stream;
-
-  final ChromeStreamController<OnResourceContentCommittedEvent> _onResourceContentCommitted =
-      new ChromeStreamController<OnResourceContentCommittedEvent>.twoArgs(_devtools_inspectedWindow, 'onResourceContentCommitted', _createOnResourceContentCommittedEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.devtools.inspectedWindow' is not available");
@@ -248,9 +250,28 @@ OnResourceContentCommittedEvent _createOnResourceContentCommittedEvent(JsObject 
  * network requests displayed by the Developer Tools in the Network panel.
  */
 class ChromeDevtoolsNetwork extends ChromeApi {
-  static final JsObject _devtools_network = chrome['devtools']['network'];
+  JsObject get _devtools_network => chrome['devtools']['network'];
 
-  ChromeDevtoolsNetwork._();
+  /**
+   * Fired when a network request is finished and all request data are
+   * available.
+   */
+  Stream<Request> get onRequestFinished => _onRequestFinished.stream;
+  ChromeStreamController<Request> _onRequestFinished;
+
+  /**
+   * Fired when the inspected window navigates to a new page.
+   */
+  Stream<String> get onNavigated => _onNavigated.stream;
+  ChromeStreamController<String> _onNavigated;
+
+  ChromeDevtoolsNetwork._() {
+    var getApi = () => _devtools_network;
+    _onRequestFinished =
+        new ChromeStreamController<Request>.oneArg(getApi, 'onRequestFinished', _createRequest);
+    _onNavigated =
+        new ChromeStreamController<String>.oneArg(getApi, 'onNavigated', selfConverter);
+  }
 
   bool get available => _devtools_network != null;
 
@@ -267,23 +288,6 @@ class ChromeDevtoolsNetwork extends ChromeApi {
     _devtools_network.callMethod('getHAR', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a network request is finished and all request data are
-   * available.
-   */
-  Stream<Request> get onRequestFinished => _onRequestFinished.stream;
-
-  final ChromeStreamController<Request> _onRequestFinished =
-      new ChromeStreamController<Request>.oneArg(_devtools_network, 'onRequestFinished', _createRequest);
-
-  /**
-   * Fired when the inspected window navigates to a new page.
-   */
-  Stream<String> get onNavigated => _onNavigated.stream;
-
-  final ChromeStreamController<String> _onNavigated =
-      new ChromeStreamController<String>.oneArg(_devtools_network, 'onNavigated', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.devtools.network' is not available");
@@ -335,7 +339,7 @@ Request _createRequest(JsObject jsProxy) => jsProxy == null ? null : new Request
  * and add sidebars.
  */
 class ChromeDevtoolsPanels extends ChromeApi {
-  static final JsObject _devtools_panels = chrome['devtools']['panels'];
+  JsObject get _devtools_panels => chrome['devtools']['panels'];
 
   ChromeDevtoolsPanels._();
 

--- a/lib/gen/downloads.dart
+++ b/lib/gen/downloads.dart
@@ -14,9 +14,31 @@ import '../src/common.dart';
 final ChromeDownloads downloads = new ChromeDownloads._();
 
 class ChromeDownloads extends ChromeApi {
-  static final JsObject _downloads = chrome['downloads'];
+  JsObject get _downloads => chrome['downloads'];
 
-  ChromeDownloads._();
+  Stream<DownloadItem> get onCreated => _onCreated.stream;
+  ChromeStreamController<DownloadItem> _onCreated;
+
+  Stream<int> get onErased => _onErased.stream;
+  ChromeStreamController<int> _onErased;
+
+  Stream<DownloadDelta> get onChanged => _onChanged.stream;
+  ChromeStreamController<DownloadDelta> _onChanged;
+
+  Stream<OnDeterminingFilenameEvent> get onDeterminingFilename => _onDeterminingFilename.stream;
+  ChromeStreamController<OnDeterminingFilenameEvent> _onDeterminingFilename;
+
+  ChromeDownloads._() {
+    var getApi = () => _downloads;
+    _onCreated =
+        new ChromeStreamController<DownloadItem>.oneArg(getApi, 'onCreated', _createDownloadItem);
+    _onErased =
+        new ChromeStreamController<int>.oneArg(getApi, 'onErased', selfConverter);
+    _onChanged =
+        new ChromeStreamController<DownloadDelta>.oneArg(getApi, 'onChanged', _createDownloadDelta);
+    _onDeterminingFilename =
+        new ChromeStreamController<OnDeterminingFilenameEvent>.twoArgs(getApi, 'onDeterminingFilename', _createOnDeterminingFilenameEvent);
+  }
 
   bool get available => _downloads != null;
 
@@ -220,26 +242,6 @@ class ChromeDownloads extends ChromeApi {
 
     _downloads.callMethod('setShelfEnabled', [enabled]);
   }
-
-  Stream<DownloadItem> get onCreated => _onCreated.stream;
-
-  final ChromeStreamController<DownloadItem> _onCreated =
-      new ChromeStreamController<DownloadItem>.oneArg(_downloads, 'onCreated', _createDownloadItem);
-
-  Stream<int> get onErased => _onErased.stream;
-
-  final ChromeStreamController<int> _onErased =
-      new ChromeStreamController<int>.oneArg(_downloads, 'onErased', selfConverter);
-
-  Stream<DownloadDelta> get onChanged => _onChanged.stream;
-
-  final ChromeStreamController<DownloadDelta> _onChanged =
-      new ChromeStreamController<DownloadDelta>.oneArg(_downloads, 'onChanged', _createDownloadDelta);
-
-  Stream<OnDeterminingFilenameEvent> get onDeterminingFilename => _onDeterminingFilename.stream;
-
-  final ChromeStreamController<OnDeterminingFilenameEvent> _onDeterminingFilename =
-      new ChromeStreamController<OnDeterminingFilenameEvent>.twoArgs(_downloads, 'onDeterminingFilename', _createOnDeterminingFilenameEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.downloads' is not available");

--- a/lib/gen/events.dart
+++ b/lib/gen/events.dart
@@ -13,7 +13,7 @@ import '../src/common.dart';
 final ChromeEvents events = new ChromeEvents._();
 
 class ChromeEvents extends ChromeApi {
-  static final JsObject _events = chrome['events'];
+  JsObject get _events => chrome['events'];
 
   ChromeEvents._();
 

--- a/lib/gen/extension.dart
+++ b/lib/gen/extension.dart
@@ -18,9 +18,27 @@ import '../src/common.dart';
 final ChromeExtension extension = new ChromeExtension._();
 
 class ChromeExtension extends ChromeApi {
-  static final JsObject _extension = chrome['extension'];
+  JsObject get _extension => chrome['extension'];
 
-  ChromeExtension._();
+  /**
+   * Deprecated: please use onMessage.
+   */
+  Stream<OnRequestEvent> get onRequest => _onRequest.stream;
+  ChromeStreamController<OnRequestEvent> _onRequest;
+
+  /**
+   * Deprecated: please use onMessageExternal.
+   */
+  Stream<OnRequestExternalEvent> get onRequestExternal => _onRequestExternal.stream;
+  ChromeStreamController<OnRequestExternalEvent> _onRequestExternal;
+
+  ChromeExtension._() {
+    var getApi = () => _extension;
+    _onRequest =
+        new ChromeStreamController<OnRequestEvent>.threeArgs(getApi, 'onRequest', _createOnRequestEvent);
+    _onRequestExternal =
+        new ChromeStreamController<OnRequestExternalEvent>.threeArgs(getApi, 'onRequestExternal', _createOnRequestExternalEvent);
+  }
 
   bool get available => _extension != null;
 
@@ -155,22 +173,6 @@ class ChromeExtension extends ChromeApi {
     _extension.callMethod('setUpdateUrlData', [data]);
   }
 
-  /**
-   * Deprecated: please use onMessage.
-   */
-  Stream<OnRequestEvent> get onRequest => _onRequest.stream;
-
-  final ChromeStreamController<OnRequestEvent> _onRequest =
-      new ChromeStreamController<OnRequestEvent>.threeArgs(_extension, 'onRequest', _createOnRequestEvent);
-
-  /**
-   * Deprecated: please use onMessageExternal.
-   */
-  Stream<OnRequestExternalEvent> get onRequestExternal => _onRequestExternal.stream;
-
-  final ChromeStreamController<OnRequestExternalEvent> _onRequestExternal =
-      new ChromeStreamController<OnRequestExternalEvent>.threeArgs(_extension, 'onRequestExternal', _createOnRequestExternalEvent);
-
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.extension' is not available");
   }
@@ -257,10 +259,10 @@ class ExtensionGetViewsParams extends ChromeObject {
   set windowId(int value) => jsProxy['windowId'] = value;
 }
 
-LastErrorExtension _createLastErrorExtension(JsObject jsProxy) => jsProxy == null ? null : new LastErrorExtension.fromProxy(jsProxy);
-Window _createWindow(JsObject jsProxy) => jsProxy == null ? null : new Window.fromProxy(jsProxy);
 OnRequestEvent _createOnRequestEvent(JsObject request, JsObject sender, JsObject sendResponse) =>
     new OnRequestEvent(request, _createMessageSender(sender), sendResponse);
 OnRequestExternalEvent _createOnRequestExternalEvent(JsObject request, JsObject sender, JsObject sendResponse) =>
     new OnRequestExternalEvent(request, _createMessageSender(sender), sendResponse);
+LastErrorExtension _createLastErrorExtension(JsObject jsProxy) => jsProxy == null ? null : new LastErrorExtension.fromProxy(jsProxy);
+Window _createWindow(JsObject jsProxy) => jsProxy == null ? null : new Window.fromProxy(jsProxy);
 MessageSender _createMessageSender(JsObject jsProxy) => jsProxy == null ? null : new MessageSender.fromProxy(jsProxy);

--- a/lib/gen/file_browser_handler.dart
+++ b/lib/gen/file_browser_handler.dart
@@ -15,9 +15,19 @@ import '../src/common.dart';
 final ChromeFileBrowserHandler fileBrowserHandler = new ChromeFileBrowserHandler._();
 
 class ChromeFileBrowserHandler extends ChromeApi {
-  static final JsObject _fileBrowserHandler = chrome['fileBrowserHandler'];
+  JsObject get _fileBrowserHandler => chrome['fileBrowserHandler'];
 
-  ChromeFileBrowserHandler._();
+  /**
+   * Fired when file system action is executed from ChromeOS file browser.
+   */
+  Stream<OnExecuteEvent> get onExecute => _onExecute.stream;
+  ChromeStreamController<OnExecuteEvent> _onExecute;
+
+  ChromeFileBrowserHandler._() {
+    var getApi = () => _fileBrowserHandler;
+    _onExecute =
+        new ChromeStreamController<OnExecuteEvent>.twoArgs(getApi, 'onExecute', _createOnExecuteEvent);
+  }
 
   bool get available => _fileBrowserHandler != null;
 
@@ -41,14 +51,6 @@ class ChromeFileBrowserHandler extends ChromeApi {
     _fileBrowserHandler.callMethod('selectFile', [jsify(selectionParams), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when file system action is executed from ChromeOS file browser.
-   */
-  Stream<OnExecuteEvent> get onExecute => _onExecute.stream;
-
-  final ChromeStreamController<OnExecuteEvent> _onExecute =
-      new ChromeStreamController<OnExecuteEvent>.twoArgs(_fileBrowserHandler, 'onExecute', _createOnExecuteEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.fileBrowserHandler' is not available");

--- a/lib/gen/file_system.dart
+++ b/lib/gen/file_system.dart
@@ -18,7 +18,7 @@ import '../src/common.dart';
 final ChromeFileSystem fileSystem = new ChromeFileSystem._();
 
 class ChromeFileSystem extends ChromeApi {
-  static final JsObject _fileSystem = chrome['fileSystem'];
+  JsObject get _fileSystem => chrome['fileSystem'];
 
   ChromeFileSystem._();
 

--- a/lib/gen/font_settings.dart
+++ b/lib/gen/font_settings.dart
@@ -13,9 +13,43 @@ import '../src/common.dart';
 final ChromeFontSettings fontSettings = new ChromeFontSettings._();
 
 class ChromeFontSettings extends ChromeApi {
-  static final JsObject _fontSettings = chrome['fontSettings'];
+  JsObject get _fontSettings => chrome['fontSettings'];
 
-  ChromeFontSettings._();
+  /**
+   * Fired when a font setting changes.
+   */
+  Stream<Map> get onFontChanged => _onFontChanged.stream;
+  ChromeStreamController<Map> _onFontChanged;
+
+  /**
+   * Fired when the default font size setting changes.
+   */
+  Stream<Map> get onDefaultFontSizeChanged => _onDefaultFontSizeChanged.stream;
+  ChromeStreamController<Map> _onDefaultFontSizeChanged;
+
+  /**
+   * Fired when the default fixed font size setting changes.
+   */
+  Stream<Map> get onDefaultFixedFontSizeChanged => _onDefaultFixedFontSizeChanged.stream;
+  ChromeStreamController<Map> _onDefaultFixedFontSizeChanged;
+
+  /**
+   * Fired when the minimum font size setting changes.
+   */
+  Stream<Map> get onMinimumFontSizeChanged => _onMinimumFontSizeChanged.stream;
+  ChromeStreamController<Map> _onMinimumFontSizeChanged;
+
+  ChromeFontSettings._() {
+    var getApi = () => _fontSettings;
+    _onFontChanged =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onFontChanged', mapify);
+    _onDefaultFontSizeChanged =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onDefaultFontSizeChanged', mapify);
+    _onDefaultFixedFontSizeChanged =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onDefaultFixedFontSizeChanged', mapify);
+    _onMinimumFontSizeChanged =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onMinimumFontSizeChanged', mapify);
+  }
 
   bool get available => _fontSettings != null;
 
@@ -173,38 +207,6 @@ class ChromeFontSettings extends ChromeApi {
     _fontSettings.callMethod('setMinimumFontSize', [jsify(details), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a font setting changes.
-   */
-  Stream<Map> get onFontChanged => _onFontChanged.stream;
-
-  final ChromeStreamController<Map> _onFontChanged =
-      new ChromeStreamController<Map>.oneArg(_fontSettings, 'onFontChanged', mapify);
-
-  /**
-   * Fired when the default font size setting changes.
-   */
-  Stream<Map> get onDefaultFontSizeChanged => _onDefaultFontSizeChanged.stream;
-
-  final ChromeStreamController<Map> _onDefaultFontSizeChanged =
-      new ChromeStreamController<Map>.oneArg(_fontSettings, 'onDefaultFontSizeChanged', mapify);
-
-  /**
-   * Fired when the default fixed font size setting changes.
-   */
-  Stream<Map> get onDefaultFixedFontSizeChanged => _onDefaultFixedFontSizeChanged.stream;
-
-  final ChromeStreamController<Map> _onDefaultFixedFontSizeChanged =
-      new ChromeStreamController<Map>.oneArg(_fontSettings, 'onDefaultFixedFontSizeChanged', mapify);
-
-  /**
-   * Fired when the minimum font size setting changes.
-   */
-  Stream<Map> get onMinimumFontSizeChanged => _onMinimumFontSizeChanged.stream;
-
-  final ChromeStreamController<Map> _onMinimumFontSizeChanged =
-      new ChromeStreamController<Map>.oneArg(_fontSettings, 'onMinimumFontSizeChanged', mapify);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.fontSettings' is not available");

--- a/lib/gen/i18n.dart
+++ b/lib/gen/i18n.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromeI18N i18n = new ChromeI18N._();
 
 class ChromeI18N extends ChromeApi {
-  static final JsObject _i18n = chrome['i18n'];
+  JsObject get _i18n => chrome['i18n'];
 
   ChromeI18N._();
 

--- a/lib/gen/identity.dart
+++ b/lib/gen/identity.dart
@@ -13,9 +13,16 @@ import '../src/common.dart';
 final ChromeIdentity identity = new ChromeIdentity._();
 
 class ChromeIdentity extends ChromeApi {
-  static final JsObject _identity = chrome['identity'];
+  JsObject get _identity => chrome['identity'];
 
-  ChromeIdentity._();
+  Stream<OnSignInChangedEvent> get onSignInChanged => _onSignInChanged.stream;
+  ChromeStreamController<OnSignInChangedEvent> _onSignInChanged;
+
+  ChromeIdentity._() {
+    var getApi = () => _identity;
+    _onSignInChanged =
+        new ChromeStreamController<OnSignInChangedEvent>.twoArgs(getApi, 'onSignInChanged', _createOnSignInChangedEvent);
+  }
 
   bool get available => _identity != null;
 
@@ -77,11 +84,6 @@ class ChromeIdentity extends ChromeApi {
     _identity.callMethod('launchWebAuthFlow', [jsify(details), completer.callback]);
     return completer.future;
   }
-
-  Stream<OnSignInChangedEvent> get onSignInChanged => _onSignInChanged.stream;
-
-  final ChromeStreamController<OnSignInChangedEvent> _onSignInChanged =
-      new ChromeStreamController<OnSignInChangedEvent>.twoArgs(_identity, 'onSignInChanged', _createOnSignInChangedEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.identity' is not available");

--- a/lib/gen/idle.dart
+++ b/lib/gen/idle.dart
@@ -13,9 +13,23 @@ import '../src/common.dart';
 final ChromeIdle idle = new ChromeIdle._();
 
 class ChromeIdle extends ChromeApi {
-  static final JsObject _idle = chrome['idle'];
+  JsObject get _idle => chrome['idle'];
 
-  ChromeIdle._();
+  /**
+   * Fired when the system changes to an active, idle or locked state. The event
+   * fires with "locked" if the screen is locked or the screensaver activates,
+   * "idle" if the system is unlocked and the user has not generated any input
+   * for a specified number of seconds, and "active" when the user generates
+   * input on an idle system.
+   */
+  Stream<String> get onStateChanged => _onStateChanged.stream;
+  ChromeStreamController<String> _onStateChanged;
+
+  ChromeIdle._() {
+    var getApi = () => _idle;
+    _onStateChanged =
+        new ChromeStreamController<String>.oneArg(getApi, 'onStateChanged', selfConverter);
+  }
 
   bool get available => _idle != null;
 
@@ -51,18 +65,6 @@ class ChromeIdle extends ChromeApi {
 
     _idle.callMethod('setDetectionInterval', [intervalInSeconds]);
   }
-
-  /**
-   * Fired when the system changes to an active, idle or locked state. The event
-   * fires with "locked" if the screen is locked or the screensaver activates,
-   * "idle" if the system is unlocked and the user has not generated any input
-   * for a specified number of seconds, and "active" when the user generates
-   * input on an idle system.
-   */
-  Stream<String> get onStateChanged => _onStateChanged.stream;
-
-  final ChromeStreamController<String> _onStateChanged =
-      new ChromeStreamController<String>.oneArg(_idle, 'onStateChanged', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.idle' is not available");

--- a/lib/gen/infobars.dart
+++ b/lib/gen/infobars.dart
@@ -15,7 +15,7 @@ import '../src/common.dart';
 final ChromeInfobars infobars = new ChromeInfobars._();
 
 class ChromeInfobars extends ChromeApi {
-  static final JsObject _infobars = chrome['infobars'];
+  JsObject get _infobars => chrome['infobars'];
 
   ChromeInfobars._();
 

--- a/lib/gen/input.dart
+++ b/lib/gen/input.dart
@@ -21,9 +21,99 @@ class ChromeInput {
  * the candidate window.
  */
 class ChromeInputIme extends ChromeApi {
-  static final JsObject _input_ime = chrome['input']['ime'];
+  JsObject get _input_ime => chrome['input']['ime'];
 
-  ChromeInputIme._();
+  /**
+   * This event is sent when an IME is activated. It signals that the IME will
+   * be receiving onKeyPress events.
+   */
+  Stream<String> get onActivate => _onActivate.stream;
+  ChromeStreamController<String> _onActivate;
+
+  /**
+   * This event is sent when an IME is deactivated. It signals that the IME will
+   * no longer be receiving onKeyPress events.
+   */
+  Stream<String> get onDeactivated => _onDeactivated.stream;
+  ChromeStreamController<String> _onDeactivated;
+
+  /**
+   * This event is sent when focus enters a text box. It is sent to all
+   * extensions that are listening to this event, and enabled by the user.
+   */
+  Stream<InputContext> get onFocus => _onFocus.stream;
+  ChromeStreamController<InputContext> _onFocus;
+
+  /**
+   * This event is sent when focus leaves a text box. It is sent to all
+   * extensions that are listening to this event, and enabled by the user.
+   */
+  Stream<int> get onBlur => _onBlur.stream;
+  ChromeStreamController<int> _onBlur;
+
+  /**
+   * This event is sent when the properties of the current InputContext change,
+   * such as the the type. It is sent to all extensions that are listening to
+   * this event, and enabled by the user.
+   */
+  Stream<InputContext> get onInputContextUpdate => _onInputContextUpdate.stream;
+  ChromeStreamController<InputContext> _onInputContextUpdate;
+
+  /**
+   * This event is sent if this extension owns the active IME.
+   */
+  Stream<OnKeyEventEvent> get onKeyEvent => _onKeyEvent.stream;
+  ChromeStreamController<OnKeyEventEvent> _onKeyEvent;
+
+  /**
+   * This event is sent if this extension owns the active IME.
+   */
+  Stream<OnCandidateClickedEvent> get onCandidateClicked => _onCandidateClicked.stream;
+  ChromeStreamController<OnCandidateClickedEvent> _onCandidateClicked;
+
+  /**
+   * Called when the user selects a menu item
+   */
+  Stream<OnMenuItemActivatedEvent> get onMenuItemActivated => _onMenuItemActivated.stream;
+  ChromeStreamController<OnMenuItemActivatedEvent> _onMenuItemActivated;
+
+  /**
+   * Called when the editable string around caret is changed or when the caret
+   * position is moved. The text length is limited to 100 characters for each
+   * back and forth direction.
+   */
+  Stream<OnSurroundingTextChangedEvent> get onSurroundingTextChanged => _onSurroundingTextChanged.stream;
+  ChromeStreamController<OnSurroundingTextChangedEvent> _onSurroundingTextChanged;
+
+  /**
+   * This event is sent when chrome terminates ongoing text input session.
+   */
+  Stream<String> get onReset => _onReset.stream;
+  ChromeStreamController<String> _onReset;
+
+  ChromeInputIme._() {
+    var getApi = () => _input_ime;
+    _onActivate =
+        new ChromeStreamController<String>.oneArg(getApi, 'onActivate', selfConverter);
+    _onDeactivated =
+        new ChromeStreamController<String>.oneArg(getApi, 'onDeactivated', selfConverter);
+    _onFocus =
+        new ChromeStreamController<InputContext>.oneArg(getApi, 'onFocus', _createInputContext);
+    _onBlur =
+        new ChromeStreamController<int>.oneArg(getApi, 'onBlur', selfConverter);
+    _onInputContextUpdate =
+        new ChromeStreamController<InputContext>.oneArg(getApi, 'onInputContextUpdate', _createInputContext);
+    _onKeyEvent =
+        new ChromeStreamController<OnKeyEventEvent>.twoArgs(getApi, 'onKeyEvent', _createOnKeyEventEvent);
+    _onCandidateClicked =
+        new ChromeStreamController<OnCandidateClickedEvent>.threeArgs(getApi, 'onCandidateClicked', _createOnCandidateClickedEvent);
+    _onMenuItemActivated =
+        new ChromeStreamController<OnMenuItemActivatedEvent>.twoArgs(getApi, 'onMenuItemActivated', _createOnMenuItemActivatedEvent);
+    _onSurroundingTextChanged =
+        new ChromeStreamController<OnSurroundingTextChangedEvent>.twoArgs(getApi, 'onSurroundingTextChanged', _createOnSurroundingTextChangedEvent);
+    _onReset =
+        new ChromeStreamController<String>.oneArg(getApi, 'onReset', selfConverter);
+  }
 
   bool get available => _input_ime != null;
 
@@ -145,94 +235,6 @@ class ChromeInputIme extends ChromeApi {
 
     _input_ime.callMethod('keyEventHandled', [requestId, response]);
   }
-
-  /**
-   * This event is sent when an IME is activated. It signals that the IME will
-   * be receiving onKeyPress events.
-   */
-  Stream<String> get onActivate => _onActivate.stream;
-
-  final ChromeStreamController<String> _onActivate =
-      new ChromeStreamController<String>.oneArg(_input_ime, 'onActivate', selfConverter);
-
-  /**
-   * This event is sent when an IME is deactivated. It signals that the IME will
-   * no longer be receiving onKeyPress events.
-   */
-  Stream<String> get onDeactivated => _onDeactivated.stream;
-
-  final ChromeStreamController<String> _onDeactivated =
-      new ChromeStreamController<String>.oneArg(_input_ime, 'onDeactivated', selfConverter);
-
-  /**
-   * This event is sent when focus enters a text box. It is sent to all
-   * extensions that are listening to this event, and enabled by the user.
-   */
-  Stream<InputContext> get onFocus => _onFocus.stream;
-
-  final ChromeStreamController<InputContext> _onFocus =
-      new ChromeStreamController<InputContext>.oneArg(_input_ime, 'onFocus', _createInputContext);
-
-  /**
-   * This event is sent when focus leaves a text box. It is sent to all
-   * extensions that are listening to this event, and enabled by the user.
-   */
-  Stream<int> get onBlur => _onBlur.stream;
-
-  final ChromeStreamController<int> _onBlur =
-      new ChromeStreamController<int>.oneArg(_input_ime, 'onBlur', selfConverter);
-
-  /**
-   * This event is sent when the properties of the current InputContext change,
-   * such as the the type. It is sent to all extensions that are listening to
-   * this event, and enabled by the user.
-   */
-  Stream<InputContext> get onInputContextUpdate => _onInputContextUpdate.stream;
-
-  final ChromeStreamController<InputContext> _onInputContextUpdate =
-      new ChromeStreamController<InputContext>.oneArg(_input_ime, 'onInputContextUpdate', _createInputContext);
-
-  /**
-   * This event is sent if this extension owns the active IME.
-   */
-  Stream<OnKeyEventEvent> get onKeyEvent => _onKeyEvent.stream;
-
-  final ChromeStreamController<OnKeyEventEvent> _onKeyEvent =
-      new ChromeStreamController<OnKeyEventEvent>.twoArgs(_input_ime, 'onKeyEvent', _createOnKeyEventEvent);
-
-  /**
-   * This event is sent if this extension owns the active IME.
-   */
-  Stream<OnCandidateClickedEvent> get onCandidateClicked => _onCandidateClicked.stream;
-
-  final ChromeStreamController<OnCandidateClickedEvent> _onCandidateClicked =
-      new ChromeStreamController<OnCandidateClickedEvent>.threeArgs(_input_ime, 'onCandidateClicked', _createOnCandidateClickedEvent);
-
-  /**
-   * Called when the user selects a menu item
-   */
-  Stream<OnMenuItemActivatedEvent> get onMenuItemActivated => _onMenuItemActivated.stream;
-
-  final ChromeStreamController<OnMenuItemActivatedEvent> _onMenuItemActivated =
-      new ChromeStreamController<OnMenuItemActivatedEvent>.twoArgs(_input_ime, 'onMenuItemActivated', _createOnMenuItemActivatedEvent);
-
-  /**
-   * Called when the editable string around caret is changed or when the caret
-   * position is moved. The text length is limited to 100 characters for each
-   * back and forth direction.
-   */
-  Stream<OnSurroundingTextChangedEvent> get onSurroundingTextChanged => _onSurroundingTextChanged.stream;
-
-  final ChromeStreamController<OnSurroundingTextChangedEvent> _onSurroundingTextChanged =
-      new ChromeStreamController<OnSurroundingTextChangedEvent>.twoArgs(_input_ime, 'onSurroundingTextChanged', _createOnSurroundingTextChangedEvent);
-
-  /**
-   * This event is sent when chrome terminates ongoing text input session.
-   */
-  Stream<String> get onReset => _onReset.stream;
-
-  final ChromeStreamController<String> _onReset =
-      new ChromeStreamController<String>.oneArg(_input_ime, 'onReset', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.input.ime' is not available");

--- a/lib/gen/location.dart
+++ b/lib/gen/location.dart
@@ -17,9 +17,21 @@ import '../src/common.dart';
 final ChromeLocation location = new ChromeLocation._();
 
 class ChromeLocation extends ChromeApi {
-  static final JsObject _location = chrome['location'];
+  JsObject get _location => chrome['location'];
 
-  ChromeLocation._();
+  Stream<Location> get onLocationUpdate => _onLocationUpdate.stream;
+  ChromeStreamController<Location> _onLocationUpdate;
+
+  Stream<String> get onLocationError => _onLocationError.stream;
+  ChromeStreamController<String> _onLocationError;
+
+  ChromeLocation._() {
+    var getApi = () => _location;
+    _onLocationUpdate =
+        new ChromeStreamController<Location>.oneArg(getApi, 'onLocationUpdate', _createLocation);
+    _onLocationError =
+        new ChromeStreamController<String>.oneArg(getApi, 'onLocationError', selfConverter);
+  }
 
   bool get available => _location != null;
 
@@ -47,16 +59,6 @@ class ChromeLocation extends ChromeApi {
 
     _location.callMethod('clearWatch', [name]);
   }
-
-  Stream<Location> get onLocationUpdate => _onLocationUpdate.stream;
-
-  final ChromeStreamController<Location> _onLocationUpdate =
-      new ChromeStreamController<Location>.oneArg(_location, 'onLocationUpdate', _createLocation);
-
-  Stream<String> get onLocationError => _onLocationError.stream;
-
-  final ChromeStreamController<String> _onLocationError =
-      new ChromeStreamController<String>.oneArg(_location, 'onLocationError', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.location' is not available");

--- a/lib/gen/management.dart
+++ b/lib/gen/management.dart
@@ -15,9 +15,43 @@ import '../src/common.dart';
 final ChromeManagement management = new ChromeManagement._();
 
 class ChromeManagement extends ChromeApi {
-  static final JsObject _management = chrome['management'];
+  JsObject get _management => chrome['management'];
 
-  ChromeManagement._();
+  /**
+   * Fired when an app or extension has been installed.
+   */
+  Stream<ExtensionInfo> get onInstalled => _onInstalled.stream;
+  ChromeStreamController<ExtensionInfo> _onInstalled;
+
+  /**
+   * Fired when an app or extension has been uninstalled.
+   */
+  Stream<String> get onUninstalled => _onUninstalled.stream;
+  ChromeStreamController<String> _onUninstalled;
+
+  /**
+   * Fired when an app or extension has been enabled.
+   */
+  Stream<ExtensionInfo> get onEnabled => _onEnabled.stream;
+  ChromeStreamController<ExtensionInfo> _onEnabled;
+
+  /**
+   * Fired when an app or extension has been disabled.
+   */
+  Stream<ExtensionInfo> get onDisabled => _onDisabled.stream;
+  ChromeStreamController<ExtensionInfo> _onDisabled;
+
+  ChromeManagement._() {
+    var getApi = () => _management;
+    _onInstalled =
+        new ChromeStreamController<ExtensionInfo>.oneArg(getApi, 'onInstalled', _createExtensionInfo);
+    _onUninstalled =
+        new ChromeStreamController<String>.oneArg(getApi, 'onUninstalled', selfConverter);
+    _onEnabled =
+        new ChromeStreamController<ExtensionInfo>.oneArg(getApi, 'onEnabled', _createExtensionInfo);
+    _onDisabled =
+        new ChromeStreamController<ExtensionInfo>.oneArg(getApi, 'onDisabled', _createExtensionInfo);
+  }
 
   bool get available => _management != null;
 
@@ -127,38 +161,6 @@ class ChromeManagement extends ChromeApi {
     _management.callMethod('launchApp', [id, completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when an app or extension has been installed.
-   */
-  Stream<ExtensionInfo> get onInstalled => _onInstalled.stream;
-
-  final ChromeStreamController<ExtensionInfo> _onInstalled =
-      new ChromeStreamController<ExtensionInfo>.oneArg(_management, 'onInstalled', _createExtensionInfo);
-
-  /**
-   * Fired when an app or extension has been uninstalled.
-   */
-  Stream<String> get onUninstalled => _onUninstalled.stream;
-
-  final ChromeStreamController<String> _onUninstalled =
-      new ChromeStreamController<String>.oneArg(_management, 'onUninstalled', selfConverter);
-
-  /**
-   * Fired when an app or extension has been enabled.
-   */
-  Stream<ExtensionInfo> get onEnabled => _onEnabled.stream;
-
-  final ChromeStreamController<ExtensionInfo> _onEnabled =
-      new ChromeStreamController<ExtensionInfo>.oneArg(_management, 'onEnabled', _createExtensionInfo);
-
-  /**
-   * Fired when an app or extension has been disabled.
-   */
-  Stream<ExtensionInfo> get onDisabled => _onDisabled.stream;
-
-  final ChromeStreamController<ExtensionInfo> _onDisabled =
-      new ChromeStreamController<ExtensionInfo>.oneArg(_management, 'onDisabled', _createExtensionInfo);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.management' is not available");

--- a/lib/gen/media_galleries.dart
+++ b/lib/gen/media_galleries.dart
@@ -15,7 +15,7 @@ import '../src/common.dart';
 final ChromeMediaGalleries mediaGalleries = new ChromeMediaGalleries._();
 
 class ChromeMediaGalleries extends ChromeApi {
-  static final JsObject _mediaGalleries = chrome['mediaGalleries'];
+  JsObject get _mediaGalleries => chrome['mediaGalleries'];
 
   ChromeMediaGalleries._();
 

--- a/lib/gen/page_action.dart
+++ b/lib/gen/page_action.dart
@@ -16,9 +16,20 @@ import '../src/common.dart';
 final ChromePageAction pageAction = new ChromePageAction._();
 
 class ChromePageAction extends ChromeApi {
-  static final JsObject _pageAction = chrome['pageAction'];
+  JsObject get _pageAction => chrome['pageAction'];
 
-  ChromePageAction._();
+  /**
+   * Fired when a page action icon is clicked.  This event will not fire if the
+   * page action has a popup.
+   */
+  Stream<Tab> get onClicked => _onClicked.stream;
+  ChromeStreamController<Tab> _onClicked;
+
+  ChromePageAction._() {
+    var getApi = () => _pageAction;
+    _onClicked =
+        new ChromeStreamController<Tab>.oneArg(getApi, 'onClicked', _createTab);
+  }
 
   bool get available => _pageAction != null;
 
@@ -100,15 +111,6 @@ class ChromePageAction extends ChromeApi {
     _pageAction.callMethod('getPopup', [jsify(details), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a page action icon is clicked.  This event will not fire if the
-   * page action has a popup.
-   */
-  Stream<Tab> get onClicked => _onClicked.stream;
-
-  final ChromeStreamController<Tab> _onClicked =
-      new ChromeStreamController<Tab>.oneArg(_pageAction, 'onClicked', _createTab);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.pageAction' is not available");

--- a/lib/gen/page_capture.dart
+++ b/lib/gen/page_capture.dart
@@ -13,7 +13,7 @@ import '../src/common.dart';
 final ChromePageCapture pageCapture = new ChromePageCapture._();
 
 class ChromePageCapture extends ChromeApi {
-  static final JsObject _pageCapture = chrome['pageCapture'];
+  JsObject get _pageCapture => chrome['pageCapture'];
 
   ChromePageCapture._();
 

--- a/lib/gen/permissions.dart
+++ b/lib/gen/permissions.dart
@@ -16,9 +16,27 @@ import '../src/common.dart';
 final ChromePermissions permissions = new ChromePermissions._();
 
 class ChromePermissions extends ChromeApi {
-  static final JsObject _permissions = chrome['permissions'];
+  JsObject get _permissions => chrome['permissions'];
 
-  ChromePermissions._();
+  /**
+   * Fired when the extension acquires new permissions.
+   */
+  Stream<Permissions> get onAdded => _onAdded.stream;
+  ChromeStreamController<Permissions> _onAdded;
+
+  /**
+   * Fired when access to permissions has been removed from the extension.
+   */
+  Stream<Permissions> get onRemoved => _onRemoved.stream;
+  ChromeStreamController<Permissions> _onRemoved;
+
+  ChromePermissions._() {
+    var getApi = () => _permissions;
+    _onAdded =
+        new ChromeStreamController<Permissions>.oneArg(getApi, 'onAdded', _createPermissions);
+    _onRemoved =
+        new ChromeStreamController<Permissions>.oneArg(getApi, 'onRemoved', _createPermissions);
+  }
 
   bool get available => _permissions != null;
 
@@ -80,22 +98,6 @@ class ChromePermissions extends ChromeApi {
     _permissions.callMethod('remove', [jsify(permissions), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when the extension acquires new permissions.
-   */
-  Stream<Permissions> get onAdded => _onAdded.stream;
-
-  final ChromeStreamController<Permissions> _onAdded =
-      new ChromeStreamController<Permissions>.oneArg(_permissions, 'onAdded', _createPermissions);
-
-  /**
-   * Fired when access to permissions has been removed from the extension.
-   */
-  Stream<Permissions> get onRemoved => _onRemoved.stream;
-
-  final ChromeStreamController<Permissions> _onRemoved =
-      new ChromeStreamController<Permissions>.oneArg(_permissions, 'onRemoved', _createPermissions);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.permissions' is not available");

--- a/lib/gen/power.dart
+++ b/lib/gen/power.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromePower power = new ChromePower._();
 
 class ChromePower extends ChromeApi {
-  static final JsObject _power = chrome['power'];
+  JsObject get _power => chrome['power'];
 
   ChromePower._();
 

--- a/lib/gen/privacy.dart
+++ b/lib/gen/privacy.dart
@@ -17,7 +17,7 @@ import '../src/common.dart';
 final ChromePrivacy privacy = new ChromePrivacy._();
 
 class ChromePrivacy extends ChromeApi {
-  static final JsObject _privacy = chrome['privacy'];
+  JsObject get _privacy => chrome['privacy'];
 
   ChromePrivacy._();
 

--- a/lib/gen/proxy.dart
+++ b/lib/gen/proxy.dart
@@ -16,9 +16,19 @@ import '../src/common.dart';
 final ChromeProxy proxy = new ChromeProxy._();
 
 class ChromeProxy extends ChromeApi {
-  static final JsObject _proxy = chrome['proxy'];
+  JsObject get _proxy => chrome['proxy'];
 
-  ChromeProxy._();
+  /**
+   * Notifies about proxy errors.
+   */
+  Stream<Map> get onProxyError => _onProxyError.stream;
+  ChromeStreamController<Map> _onProxyError;
+
+  ChromeProxy._() {
+    var getApi = () => _proxy;
+    _onProxyError =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onProxyError', mapify);
+  }
 
   bool get available => _proxy != null;
 
@@ -27,14 +37,6 @@ class ChromeProxy extends ChromeApi {
    * object.
    */
   ChromeSetting get settings => _createChromeSetting(_proxy['settings']);
-
-  /**
-   * Notifies about proxy errors.
-   */
-  Stream<Map> get onProxyError => _onProxyError.stream;
-
-  final ChromeStreamController<Map> _onProxyError =
-      new ChromeStreamController<Map>.oneArg(_proxy, 'onProxyError', mapify);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.proxy' is not available");

--- a/lib/gen/push_messaging.dart
+++ b/lib/gen/push_messaging.dart
@@ -14,9 +14,16 @@ import '../src/common.dart';
 final ChromePushMessaging pushMessaging = new ChromePushMessaging._();
 
 class ChromePushMessaging extends ChromeApi {
-  static final JsObject _pushMessaging = chrome['pushMessaging'];
+  JsObject get _pushMessaging => chrome['pushMessaging'];
 
-  ChromePushMessaging._();
+  Stream<Message> get onMessage => _onMessage.stream;
+  ChromeStreamController<Message> _onMessage;
+
+  ChromePushMessaging._() {
+    var getApi = () => _pushMessaging;
+    _onMessage =
+        new ChromeStreamController<Message>.oneArg(getApi, 'onMessage', _createMessage);
+  }
 
   bool get available => _pushMessaging != null;
 
@@ -34,11 +41,6 @@ class ChromePushMessaging extends ChromeApi {
     _pushMessaging.callMethod('getChannelId', [interactive, completer.callback]);
     return completer.future;
   }
-
-  Stream<Message> get onMessage => _onMessage.stream;
-
-  final ChromeStreamController<Message> _onMessage =
-      new ChromeStreamController<Message>.oneArg(_pushMessaging, 'onMessage', _createMessage);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.pushMessaging' is not available");
@@ -69,5 +71,5 @@ class ChannelIdResult extends ChromeObject {
   set channelId(String value) => jsProxy['channelId'] = value;
 }
 
-ChannelIdResult _createChannelIdResult(JsObject jsProxy) => jsProxy == null ? null : new ChannelIdResult.fromProxy(jsProxy);
 Message _createMessage(JsObject jsProxy) => jsProxy == null ? null : new Message.fromProxy(jsProxy);
+ChannelIdResult _createChannelIdResult(JsObject jsProxy) => jsProxy == null ? null : new ChannelIdResult.fromProxy(jsProxy);

--- a/lib/gen/script_badge.dart
+++ b/lib/gen/script_badge.dart
@@ -15,9 +15,20 @@ import '../src/common.dart';
 final ChromeScriptBadge scriptBadge = new ChromeScriptBadge._();
 
 class ChromeScriptBadge extends ChromeApi {
-  static final JsObject _scriptBadge = chrome['scriptBadge'];
+  JsObject get _scriptBadge => chrome['scriptBadge'];
 
-  ChromeScriptBadge._();
+  /**
+   * Fired when a script badge icon is clicked.  This event will not fire if the
+   * script badge has a popup.
+   */
+  Stream<Tab> get onClicked => _onClicked.stream;
+  ChromeStreamController<Tab> _onClicked;
+
+  ChromeScriptBadge._() {
+    var getApi = () => _scriptBadge;
+    _onClicked =
+        new ChromeStreamController<Tab>.oneArg(getApi, 'onClicked', _createTab);
+  }
 
   bool get available => _scriptBadge != null;
 
@@ -54,15 +65,6 @@ class ChromeScriptBadge extends ChromeApi {
 
     _scriptBadge.callMethod('getAttention', [jsify(details)]);
   }
-
-  /**
-   * Fired when a script badge icon is clicked.  This event will not fire if the
-   * script badge has a popup.
-   */
-  Stream<Tab> get onClicked => _onClicked.stream;
-
-  final ChromeStreamController<Tab> _onClicked =
-      new ChromeStreamController<Tab>.oneArg(_scriptBadge, 'onClicked', _createTab);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.scriptBadge' is not available");

--- a/lib/gen/serial.dart
+++ b/lib/gen/serial.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromeSerial serial = new ChromeSerial._();
 
 class ChromeSerial extends ChromeApi {
-  static final JsObject _serial = chrome['serial'];
+  JsObject get _serial => chrome['serial'];
 
   ChromeSerial._();
 

--- a/lib/gen/sessions.dart
+++ b/lib/gen/sessions.dart
@@ -16,7 +16,7 @@ import '../src/common.dart';
 final ChromeSessions sessions = new ChromeSessions._();
 
 class ChromeSessions extends ChromeApi {
-  static final JsObject _sessions = chrome['sessions'];
+  JsObject get _sessions => chrome['sessions'];
 
   ChromeSessions._();
 

--- a/lib/gen/signed_in_devices.dart
+++ b/lib/gen/signed_in_devices.dart
@@ -14,9 +14,16 @@ import '../src/common.dart';
 final ChromeSignedInDevices signedInDevices = new ChromeSignedInDevices._();
 
 class ChromeSignedInDevices extends ChromeApi {
-  static final JsObject _signedInDevices = chrome['signedInDevices'];
+  JsObject get _signedInDevices => chrome['signedInDevices'];
 
-  ChromeSignedInDevices._();
+  Stream<List<DeviceInfo>> get onDeviceInfoChange => _onDeviceInfoChange.stream;
+  ChromeStreamController<List<DeviceInfo>> _onDeviceInfoChange;
+
+  ChromeSignedInDevices._() {
+    var getApi = () => _signedInDevices;
+    _onDeviceInfoChange =
+        new ChromeStreamController<List<DeviceInfo>>.oneArg(getApi, 'onDeviceInfoChange', (e) => listify(e, _createDeviceInfo));
+  }
 
   bool get available => _signedInDevices != null;
 
@@ -35,11 +42,6 @@ class ChromeSignedInDevices extends ChromeApi {
     _signedInDevices.callMethod('get', [isLocal, completer.callback]);
     return completer.future;
   }
-
-  Stream<List<DeviceInfo>> get onDeviceInfoChange => _onDeviceInfoChange.stream;
-
-  final ChromeStreamController<List<DeviceInfo>> _onDeviceInfoChange =
-      new ChromeStreamController<List<DeviceInfo>>.oneArg(_signedInDevices, 'onDeviceInfoChange', (e) => listify(e, _createDeviceInfo));
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.signedInDevices' is not available");

--- a/lib/gen/socket.dart
+++ b/lib/gen/socket.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromeSocket socket = new ChromeSocket._();
 
 class ChromeSocket extends ChromeApi {
-  static final JsObject _socket = chrome['socket'];
+  JsObject get _socket => chrome['socket'];
 
   ChromeSocket._();
 

--- a/lib/gen/sockets.dart
+++ b/lib/gen/sockets.dart
@@ -32,9 +32,21 @@ class ChromeSockets {
  * namespace are not compatible with ids created in other namespaces.
  */
 class ChromeSocketsTcp extends ChromeApi {
-  static final JsObject _sockets_tcp = chrome['sockets']['tcp'];
+  JsObject get _sockets_tcp => chrome['sockets']['tcp'];
 
-  ChromeSocketsTcp._();
+  Stream<ReceiveInfo> get onReceive => _onReceive.stream;
+  ChromeStreamController<ReceiveInfo> _onReceive;
+
+  Stream<ReceiveErrorInfo> get onReceiveError => _onReceiveError.stream;
+  ChromeStreamController<ReceiveErrorInfo> _onReceiveError;
+
+  ChromeSocketsTcp._() {
+    var getApi = () => _sockets_tcp;
+    _onReceive =
+        new ChromeStreamController<ReceiveInfo>.oneArg(getApi, 'onReceive', _createReceiveInfo);
+    _onReceiveError =
+        new ChromeStreamController<ReceiveErrorInfo>.oneArg(getApi, 'onReceiveError', _createReceiveErrorInfo);
+  }
 
   bool get available => _sockets_tcp != null;
 
@@ -231,16 +243,6 @@ class ChromeSocketsTcp extends ChromeApi {
     return completer.future;
   }
 
-  Stream<ReceiveInfo> get onReceive => _onReceive.stream;
-
-  final ChromeStreamController<ReceiveInfo> _onReceive =
-      new ChromeStreamController<ReceiveInfo>.oneArg(_sockets_tcp, 'onReceive', _createReceiveInfo);
-
-  Stream<ReceiveErrorInfo> get onReceiveError => _onReceiveError.stream;
-
-  final ChromeStreamController<ReceiveErrorInfo> _onReceiveError =
-      new ChromeStreamController<ReceiveErrorInfo>.oneArg(_sockets_tcp, 'onReceiveError', _createReceiveErrorInfo);
-
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.sockets.tcp' is not available");
   }
@@ -383,11 +385,11 @@ class ReceiveErrorInfo extends ChromeObject {
   set resultCode(int value) => jsProxy['resultCode'] = value;
 }
 
+ReceiveInfo _createReceiveInfo(JsObject jsProxy) => jsProxy == null ? null : new ReceiveInfo.fromProxy(jsProxy);
+ReceiveErrorInfo _createReceiveErrorInfo(JsObject jsProxy) => jsProxy == null ? null : new ReceiveErrorInfo.fromProxy(jsProxy);
 CreateInfo _createCreateInfo(JsObject jsProxy) => jsProxy == null ? null : new CreateInfo.fromProxy(jsProxy);
 SendInfo _createSendInfo(JsObject jsProxy) => jsProxy == null ? null : new SendInfo.fromProxy(jsProxy);
 SocketInfo _createSocketInfo(JsObject jsProxy) => jsProxy == null ? null : new SocketInfo.fromProxy(jsProxy);
-ReceiveInfo _createReceiveInfo(JsObject jsProxy) => jsProxy == null ? null : new ReceiveInfo.fromProxy(jsProxy);
-ReceiveErrorInfo _createReceiveErrorInfo(JsObject jsProxy) => jsProxy == null ? null : new ReceiveErrorInfo.fromProxy(jsProxy);
 ArrayBuffer _createArrayBuffer(/*JsObject*/ jsProxy) => jsProxy == null ? null : new ArrayBuffer.fromProxy(jsProxy);
 
 /**
@@ -397,9 +399,21 @@ ArrayBuffer _createArrayBuffer(/*JsObject*/ jsProxy) => jsProxy == null ? null :
  * namespace are not compatible with ids created in other namespaces.
  */
 class ChromeSocketsTcpServer extends ChromeApi {
-  static final JsObject _sockets_tcpServer = chrome['sockets']['tcpServer'];
+  JsObject get _sockets_tcpServer => chrome['sockets']['tcpServer'];
 
-  ChromeSocketsTcpServer._();
+  Stream<AcceptInfo> get onAccept => _onAccept.stream;
+  ChromeStreamController<AcceptInfo> _onAccept;
+
+  Stream<AcceptErrorInfo> get onAcceptError => _onAcceptError.stream;
+  ChromeStreamController<AcceptErrorInfo> _onAcceptError;
+
+  ChromeSocketsTcpServer._() {
+    var getApi = () => _sockets_tcpServer;
+    _onAccept =
+        new ChromeStreamController<AcceptInfo>.oneArg(getApi, 'onAccept', _createAcceptInfo);
+    _onAcceptError =
+        new ChromeStreamController<AcceptErrorInfo>.oneArg(getApi, 'onAcceptError', _createAcceptErrorInfo);
+  }
 
   bool get available => _sockets_tcpServer != null;
 
@@ -537,16 +551,6 @@ class ChromeSocketsTcpServer extends ChromeApi {
     return completer.future;
   }
 
-  Stream<AcceptInfo> get onAccept => _onAccept.stream;
-
-  final ChromeStreamController<AcceptInfo> _onAccept =
-      new ChromeStreamController<AcceptInfo>.oneArg(_sockets_tcpServer, 'onAccept', _createAcceptInfo);
-
-  Stream<AcceptErrorInfo> get onAcceptError => _onAcceptError.stream;
-
-  final ChromeStreamController<AcceptErrorInfo> _onAcceptError =
-      new ChromeStreamController<AcceptErrorInfo>.oneArg(_sockets_tcpServer, 'onAcceptError', _createAcceptErrorInfo);
-
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.sockets.tcpServer' is not available");
   }
@@ -596,9 +600,21 @@ AcceptErrorInfo _createAcceptErrorInfo(JsObject jsProxy) => jsProxy == null ? nu
  * namespace are not compatible with ids created in other namespaces.
  */
 class ChromeSocketsUdp extends ChromeApi {
-  static final JsObject _sockets_udp = chrome['sockets']['udp'];
+  JsObject get _sockets_udp => chrome['sockets']['udp'];
 
-  ChromeSocketsUdp._();
+  Stream<ReceiveInfo> get onReceive => _onReceive.stream;
+  ChromeStreamController<ReceiveInfo> _onReceive;
+
+  Stream<ReceiveErrorInfo> get onReceiveError => _onReceiveError.stream;
+  ChromeStreamController<ReceiveErrorInfo> _onReceiveError;
+
+  ChromeSocketsUdp._() {
+    var getApi = () => _sockets_udp;
+    _onReceive =
+        new ChromeStreamController<ReceiveInfo>.oneArg(getApi, 'onReceive', _createReceiveInfo);
+    _onReceiveError =
+        new ChromeStreamController<ReceiveErrorInfo>.oneArg(getApi, 'onReceiveError', _createReceiveErrorInfo);
+  }
 
   bool get available => _sockets_udp != null;
 
@@ -844,16 +860,6 @@ class ChromeSocketsUdp extends ChromeApi {
     _sockets_udp.callMethod('getJoinedGroups', [socketId, completer.callback]);
     return completer.future;
   }
-
-  Stream<ReceiveInfo> get onReceive => _onReceive.stream;
-
-  final ChromeStreamController<ReceiveInfo> _onReceive =
-      new ChromeStreamController<ReceiveInfo>.oneArg(_sockets_udp, 'onReceive', _createReceiveInfo);
-
-  Stream<ReceiveErrorInfo> get onReceiveError => _onReceiveError.stream;
-
-  final ChromeStreamController<ReceiveErrorInfo> _onReceiveError =
-      new ChromeStreamController<ReceiveErrorInfo>.oneArg(_sockets_udp, 'onReceiveError', _createReceiveErrorInfo);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.sockets.udp' is not available");

--- a/lib/gen/storage.dart
+++ b/lib/gen/storage.dart
@@ -14,9 +14,19 @@ import '../src/common.dart';
 final ChromeStorage storage = new ChromeStorage._();
 
 class ChromeStorage extends ChromeApi {
-  static final JsObject _storage = chrome['storage'];
+  JsObject get _storage => chrome['storage'];
 
-  ChromeStorage._();
+  /**
+   * Fired when one or more items change.
+   */
+  Stream<StorageOnChangedEvent> get onChanged => _onChanged.stream;
+  ChromeStreamController<StorageOnChangedEvent> _onChanged;
+
+  ChromeStorage._() {
+    var getApi = () => _storage;
+    _onChanged =
+        new ChromeStreamController<StorageOnChangedEvent>.twoArgs(getApi, 'onChanged', _createOnChangedEvent);
+  }
 
   bool get available => _storage != null;
 
@@ -29,14 +39,6 @@ class ChromeStorage extends ChromeApi {
    * Items in the `local` storage area are local to each machine.
    */
   LocalStorageArea get local => _createLocalStorageArea(_storage['local']);
-
-  /**
-   * Fired when one or more items change.
-   */
-  Stream<StorageOnChangedEvent> get onChanged => _onChanged.stream;
-
-  final ChromeStreamController<StorageOnChangedEvent> _onChanged =
-      new ChromeStreamController<StorageOnChangedEvent>.twoArgs(_storage, 'onChanged', _createOnChangedEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.storage' is not available");
@@ -212,7 +214,7 @@ class StorageArea extends ChromeObject {
   }
 }
 
-SyncStorageArea _createSyncStorageArea(JsObject jsProxy) => jsProxy == null ? null : new SyncStorageArea.fromProxy(jsProxy);
-LocalStorageArea _createLocalStorageArea(JsObject jsProxy) => jsProxy == null ? null : new LocalStorageArea.fromProxy(jsProxy);
 StorageOnChangedEvent _createOnChangedEvent(JsObject changes, String areaName) =>
     new StorageOnChangedEvent(mapify(changes), areaName);
+SyncStorageArea _createSyncStorageArea(JsObject jsProxy) => jsProxy == null ? null : new SyncStorageArea.fromProxy(jsProxy);
+LocalStorageArea _createLocalStorageArea(JsObject jsProxy) => jsProxy == null ? null : new LocalStorageArea.fromProxy(jsProxy);

--- a/lib/gen/sync_file_system.dart
+++ b/lib/gen/sync_file_system.dart
@@ -18,9 +18,21 @@ import '../src/common.dart';
 final ChromeSyncFileSystem syncFileSystem = new ChromeSyncFileSystem._();
 
 class ChromeSyncFileSystem extends ChromeApi {
-  static final JsObject _syncFileSystem = chrome['syncFileSystem'];
+  JsObject get _syncFileSystem => chrome['syncFileSystem'];
 
-  ChromeSyncFileSystem._();
+  Stream<ServiceInfo> get onServiceStatusChanged => _onServiceStatusChanged.stream;
+  ChromeStreamController<ServiceInfo> _onServiceStatusChanged;
+
+  Stream<FileInfo> get onFileStatusChanged => _onFileStatusChanged.stream;
+  ChromeStreamController<FileInfo> _onFileStatusChanged;
+
+  ChromeSyncFileSystem._() {
+    var getApi = () => _syncFileSystem;
+    _onServiceStatusChanged =
+        new ChromeStreamController<ServiceInfo>.oneArg(getApi, 'onServiceStatusChanged', _createServiceInfo);
+    _onFileStatusChanged =
+        new ChromeStreamController<FileInfo>.oneArg(getApi, 'onFileStatusChanged', _createFileInfo);
+  }
 
   bool get available => _syncFileSystem != null;
 
@@ -133,16 +145,6 @@ class ChromeSyncFileSystem extends ChromeApi {
     _syncFileSystem.callMethod('getServiceStatus', [completer.callback]);
     return completer.future;
   }
-
-  Stream<ServiceInfo> get onServiceStatusChanged => _onServiceStatusChanged.stream;
-
-  final ChromeStreamController<ServiceInfo> _onServiceStatusChanged =
-      new ChromeStreamController<ServiceInfo>.oneArg(_syncFileSystem, 'onServiceStatusChanged', _createServiceInfo);
-
-  Stream<FileInfo> get onFileStatusChanged => _onFileStatusChanged.stream;
-
-  final ChromeStreamController<FileInfo> _onFileStatusChanged =
-      new ChromeStreamController<FileInfo>.oneArg(_syncFileSystem, 'onFileStatusChanged', _createFileInfo);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.syncFileSystem' is not available");
@@ -267,14 +269,14 @@ class ServiceInfo extends ChromeObject {
   set description(String value) => jsProxy['description'] = value;
 }
 
+ServiceInfo _createServiceInfo(JsObject jsProxy) => jsProxy == null ? null : new ServiceInfo.fromProxy(jsProxy);
+FileInfo _createFileInfo(JsObject jsProxy) => jsProxy == null ? null : new FileInfo.fromProxy(jsProxy);
 FileSystem _createDOMFileSystem(JsObject jsProxy) => jsProxy == null ? null : new CrFileSystem.fromProxy(jsProxy);
 ConflictResolutionPolicy _createConflictResolutionPolicy(String value) => ConflictResolutionPolicy.VALUES.singleWhere((ChromeEnum e) => e.value == value);
 StorageInfo _createStorageInfo(JsObject jsProxy) => jsProxy == null ? null : new StorageInfo.fromProxy(jsProxy);
 FileStatus _createFileStatus(String value) => FileStatus.VALUES.singleWhere((ChromeEnum e) => e.value == value);
 FileStatusInfo _createFileStatusInfo(JsObject jsProxy) => jsProxy == null ? null : new FileStatusInfo.fromProxy(jsProxy);
 ServiceStatus _createServiceStatus(String value) => ServiceStatus.VALUES.singleWhere((ChromeEnum e) => e.value == value);
-ServiceInfo _createServiceInfo(JsObject jsProxy) => jsProxy == null ? null : new ServiceInfo.fromProxy(jsProxy);
-FileInfo _createFileInfo(JsObject jsProxy) => jsProxy == null ? null : new FileInfo.fromProxy(jsProxy);
 Entry _createEntry(JsObject jsProxy) => jsProxy == null ? null : new CrEntry.fromProxy(jsProxy);
 SyncAction _createSyncAction(String value) => SyncAction.VALUES.singleWhere((ChromeEnum e) => e.value == value);
 SyncDirection _createSyncDirection(String value) => SyncDirection.VALUES.singleWhere((ChromeEnum e) => e.value == value);

--- a/lib/gen/system.dart
+++ b/lib/gen/system.dart
@@ -39,7 +39,7 @@ class ChromeSystem {
  * Use the `system.cpu` API to query CPU metadata.
  */
 class ChromeSystemCpu extends ChromeApi {
-  static final JsObject _system_cpu = chrome['system']['cpu'];
+  JsObject get _system_cpu => chrome['system']['cpu'];
 
   ChromeSystemCpu._();
 
@@ -85,9 +85,16 @@ CpuInfo _createCpuInfo(JsObject jsProxy) => jsProxy == null ? null : new CpuInfo
  * Use the `system.display` API to query display metadata.
  */
 class ChromeSystemDisplay extends ChromeApi {
-  static final JsObject _system_display = chrome['system']['display'];
+  JsObject get _system_display => chrome['system']['display'];
 
-  ChromeSystemDisplay._();
+  Stream get onDisplayChanged => _onDisplayChanged.stream;
+  ChromeStreamController _onDisplayChanged;
+
+  ChromeSystemDisplay._() {
+    var getApi = () => _system_display;
+    _onDisplayChanged =
+        new ChromeStreamController.noArgs(getApi, 'onDisplayChanged');
+  }
 
   bool get available => _system_display != null;
 
@@ -119,11 +126,6 @@ class ChromeSystemDisplay extends ChromeApi {
     _system_display.callMethod('setDisplayProperties', [id, jsify(info), completer.callback]);
     return completer.future;
   }
-
-  Stream get onDisplayChanged => _onDisplayChanged.stream;
-
-  final ChromeStreamController _onDisplayChanged =
-      new ChromeStreamController.noArgs(_system_display, 'onDisplayChanged');
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.system.display' is not available");
@@ -244,7 +246,7 @@ Insets _createInsets(JsObject jsProxy) => jsProxy == null ? null : new Insets.fr
  * The `chrome.system.memory` API.
  */
 class ChromeSystemMemory extends ChromeApi {
-  static final JsObject _system_memory = chrome['system']['memory'];
+  JsObject get _system_memory => chrome['system']['memory'];
 
   ChromeSystemMemory._();
 
@@ -286,7 +288,7 @@ MemoryInfo _createMemoryInfo(JsObject jsProxy) => jsProxy == null ? null : new M
  * Use the `chrome.system.network` API.
  */
 class ChromeSystemNetwork extends ChromeApi {
-  static final JsObject _system_network = chrome['system']['network'];
+  JsObject get _system_network => chrome['system']['network'];
 
   ChromeSystemNetwork._();
 
@@ -339,9 +341,21 @@ NetworkInterface _createNetworkInterface(JsObject jsProxy) => jsProxy == null ? 
  * be notified when a removable storage device is attached and detached.
  */
 class ChromeSystemStorage extends ChromeApi {
-  static final JsObject _system_storage = chrome['system']['storage'];
+  JsObject get _system_storage => chrome['system']['storage'];
 
-  ChromeSystemStorage._();
+  Stream<StorageUnitInfo> get onAttached => _onAttached.stream;
+  ChromeStreamController<StorageUnitInfo> _onAttached;
+
+  Stream<String> get onDetached => _onDetached.stream;
+  ChromeStreamController<String> _onDetached;
+
+  ChromeSystemStorage._() {
+    var getApi = () => _system_storage;
+    _onAttached =
+        new ChromeStreamController<StorageUnitInfo>.oneArg(getApi, 'onAttached', _createStorageUnitInfo);
+    _onDetached =
+        new ChromeStreamController<String>.oneArg(getApi, 'onDetached', selfConverter);
+  }
 
   bool get available => _system_storage != null;
 
@@ -379,16 +393,6 @@ class ChromeSystemStorage extends ChromeApi {
     _system_storage.callMethod('getAvailableCapacity', [id, completer.callback]);
     return completer.future;
   }
-
-  Stream<StorageUnitInfo> get onAttached => _onAttached.stream;
-
-  final ChromeStreamController<StorageUnitInfo> _onAttached =
-      new ChromeStreamController<StorageUnitInfo>.oneArg(_system_storage, 'onAttached', _createStorageUnitInfo);
-
-  Stream<String> get onDetached => _onDetached.stream;
-
-  final ChromeStreamController<String> _onDetached =
-      new ChromeStreamController<String>.oneArg(_system_storage, 'onDetached', selfConverter);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.system.storage' is not available");

--- a/lib/gen/tab_capture.dart
+++ b/lib/gen/tab_capture.dart
@@ -13,9 +13,16 @@ import '../src/common.dart';
 final ChromeTabCapture tabCapture = new ChromeTabCapture._();
 
 class ChromeTabCapture extends ChromeApi {
-  static final JsObject _tabCapture = chrome['tabCapture'];
+  JsObject get _tabCapture => chrome['tabCapture'];
 
-  ChromeTabCapture._();
+  Stream<CaptureInfo> get onStatusChanged => _onStatusChanged.stream;
+  ChromeStreamController<CaptureInfo> _onStatusChanged;
+
+  ChromeTabCapture._() {
+    var getApi = () => _tabCapture;
+    _onStatusChanged =
+        new ChromeStreamController<CaptureInfo>.oneArg(getApi, 'onStatusChanged', _createCaptureInfo);
+  }
 
   bool get available => _tabCapture != null;
 
@@ -49,11 +56,6 @@ class ChromeTabCapture extends ChromeApi {
     _tabCapture.callMethod('getCapturedTabs', [completer.callback]);
     return completer.future;
   }
-
-  Stream<CaptureInfo> get onStatusChanged => _onStatusChanged.stream;
-
-  final ChromeStreamController<CaptureInfo> _onStatusChanged =
-      new ChromeStreamController<CaptureInfo>.oneArg(_tabCapture, 'onStatusChanged', _createCaptureInfo);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.tabCapture' is not available");
@@ -134,7 +136,7 @@ class CaptureOptions extends ChromeObject {
   set videoConstraints(MediaStreamConstraint value) => jsProxy['videoConstraints'] = jsify(value);
 }
 
-LocalMediaStream _createLocalMediaStream(JsObject jsProxy) => jsProxy == null ? null : new LocalMediaStream.fromProxy(jsProxy);
 CaptureInfo _createCaptureInfo(JsObject jsProxy) => jsProxy == null ? null : new CaptureInfo.fromProxy(jsProxy);
+LocalMediaStream _createLocalMediaStream(JsObject jsProxy) => jsProxy == null ? null : new LocalMediaStream.fromProxy(jsProxy);
 TabCaptureState _createTabCaptureState(String value) => TabCaptureState.VALUES.singleWhere((ChromeEnum e) => e.value == value);
 MediaStreamConstraint _createMediaStreamConstraint(JsObject jsProxy) => jsProxy == null ? null : new MediaStreamConstraint.fromProxy(jsProxy);

--- a/lib/gen/tabs.dart
+++ b/lib/gen/tabs.dart
@@ -16,9 +16,117 @@ import '../src/common.dart';
 final ChromeTabs tabs = new ChromeTabs._();
 
 class ChromeTabs extends ChromeApi {
-  static final JsObject _tabs = chrome['tabs'];
+  JsObject get _tabs => chrome['tabs'];
 
-  ChromeTabs._();
+  /**
+   * Fired when a tab is created. Note that the tab's URL may not be set at the
+   * time this event fired, but you can listen to onUpdated events to be
+   * notified when a URL is set.
+   */
+  Stream<Tab> get onCreated => _onCreated.stream;
+  ChromeStreamController<Tab> _onCreated;
+
+  /**
+   * Fired when a tab is updated.
+   */
+  Stream<OnUpdatedEvent> get onUpdated => _onUpdated.stream;
+  ChromeStreamController<OnUpdatedEvent> _onUpdated;
+
+  /**
+   * Fired when a tab is moved within a window. Only one move event is fired,
+   * representing the tab the user directly moved. Move events are not fired for
+   * the other tabs that must move in response. This event is not fired when a
+   * tab is moved between windows. For that, see [onDetached.]
+   */
+  Stream<TabsOnMovedEvent> get onMoved => _onMoved.stream;
+  ChromeStreamController<TabsOnMovedEvent> _onMoved;
+
+  /**
+   * Deprecated. Please use onActivated.
+   */
+  Stream<OnSelectionChangedEvent> get onSelectionChanged => _onSelectionChanged.stream;
+  ChromeStreamController<OnSelectionChangedEvent> _onSelectionChanged;
+
+  /**
+   * Deprecated. Please use onActivated.
+   */
+  Stream<OnActiveChangedEvent> get onActiveChanged => _onActiveChanged.stream;
+  ChromeStreamController<OnActiveChangedEvent> _onActiveChanged;
+
+  /**
+   * Fires when the active tab in a window changes. Note that the tab's URL may
+   * not be set at the time this event fired, but you can listen to onUpdated
+   * events to be notified when a URL is set.
+   */
+  Stream<Map> get onActivated => _onActivated.stream;
+  ChromeStreamController<Map> _onActivated;
+
+  /**
+   * Deprecated. Please use onHighlighted.
+   */
+  Stream<Map> get onHighlightChanged => _onHighlightChanged.stream;
+  ChromeStreamController<Map> _onHighlightChanged;
+
+  /**
+   * Fired when the highlighted or selected tabs in a window changes.
+   */
+  Stream<Map> get onHighlighted => _onHighlighted.stream;
+  ChromeStreamController<Map> _onHighlighted;
+
+  /**
+   * Fired when a tab is detached from a window, for example because it is being
+   * moved between windows.
+   */
+  Stream<OnDetachedEvent> get onDetached => _onDetached.stream;
+  ChromeStreamController<OnDetachedEvent> _onDetached;
+
+  /**
+   * Fired when a tab is attached to a window, for example because it was moved
+   * between windows.
+   */
+  Stream<OnAttachedEvent> get onAttached => _onAttached.stream;
+  ChromeStreamController<OnAttachedEvent> _onAttached;
+
+  /**
+   * Fired when a tab is closed.
+   */
+  Stream<TabsOnRemovedEvent> get onRemoved => _onRemoved.stream;
+  ChromeStreamController<TabsOnRemovedEvent> _onRemoved;
+
+  /**
+   * Fired when a tab is replaced with another tab due to prerendering or
+   * instant.
+   */
+  Stream<OnReplacedEvent> get onReplaced => _onReplaced.stream;
+  ChromeStreamController<OnReplacedEvent> _onReplaced;
+
+  ChromeTabs._() {
+    var getApi = () => _tabs;
+    _onCreated =
+        new ChromeStreamController<Tab>.oneArg(getApi, 'onCreated', _createTab);
+    _onUpdated =
+        new ChromeStreamController<OnUpdatedEvent>.threeArgs(getApi, 'onUpdated', _createOnUpdatedEvent);
+    _onMoved =
+        new ChromeStreamController<TabsOnMovedEvent>.twoArgs(getApi, 'onMoved', _createOnMovedEvent);
+    _onSelectionChanged =
+        new ChromeStreamController<OnSelectionChangedEvent>.twoArgs(getApi, 'onSelectionChanged', _createOnSelectionChangedEvent);
+    _onActiveChanged =
+        new ChromeStreamController<OnActiveChangedEvent>.twoArgs(getApi, 'onActiveChanged', _createOnActiveChangedEvent);
+    _onActivated =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onActivated', mapify);
+    _onHighlightChanged =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onHighlightChanged', mapify);
+    _onHighlighted =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onHighlighted', mapify);
+    _onDetached =
+        new ChromeStreamController<OnDetachedEvent>.twoArgs(getApi, 'onDetached', _createOnDetachedEvent);
+    _onAttached =
+        new ChromeStreamController<OnAttachedEvent>.twoArgs(getApi, 'onAttached', _createOnAttachedEvent);
+    _onRemoved =
+        new ChromeStreamController<TabsOnRemovedEvent>.twoArgs(getApi, 'onRemoved', _createOnRemovedEvent);
+    _onReplaced =
+        new ChromeStreamController<OnReplacedEvent>.twoArgs(getApi, 'onReplaced', _createOnReplacedEvent);
+  }
 
   bool get available => _tabs != null;
 
@@ -329,112 +437,6 @@ class ChromeTabs extends ChromeApi {
     _tabs.callMethod('insertCSS', [tabId, jsify(details), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a tab is created. Note that the tab's URL may not be set at the
-   * time this event fired, but you can listen to onUpdated events to be
-   * notified when a URL is set.
-   */
-  Stream<Tab> get onCreated => _onCreated.stream;
-
-  final ChromeStreamController<Tab> _onCreated =
-      new ChromeStreamController<Tab>.oneArg(_tabs, 'onCreated', _createTab);
-
-  /**
-   * Fired when a tab is updated.
-   */
-  Stream<OnUpdatedEvent> get onUpdated => _onUpdated.stream;
-
-  final ChromeStreamController<OnUpdatedEvent> _onUpdated =
-      new ChromeStreamController<OnUpdatedEvent>.threeArgs(_tabs, 'onUpdated', _createOnUpdatedEvent);
-
-  /**
-   * Fired when a tab is moved within a window. Only one move event is fired,
-   * representing the tab the user directly moved. Move events are not fired for
-   * the other tabs that must move in response. This event is not fired when a
-   * tab is moved between windows. For that, see [onDetached.]
-   */
-  Stream<TabsOnMovedEvent> get onMoved => _onMoved.stream;
-
-  final ChromeStreamController<TabsOnMovedEvent> _onMoved =
-      new ChromeStreamController<TabsOnMovedEvent>.twoArgs(_tabs, 'onMoved', _createOnMovedEvent);
-
-  /**
-   * Deprecated. Please use onActivated.
-   */
-  Stream<OnSelectionChangedEvent> get onSelectionChanged => _onSelectionChanged.stream;
-
-  final ChromeStreamController<OnSelectionChangedEvent> _onSelectionChanged =
-      new ChromeStreamController<OnSelectionChangedEvent>.twoArgs(_tabs, 'onSelectionChanged', _createOnSelectionChangedEvent);
-
-  /**
-   * Deprecated. Please use onActivated.
-   */
-  Stream<OnActiveChangedEvent> get onActiveChanged => _onActiveChanged.stream;
-
-  final ChromeStreamController<OnActiveChangedEvent> _onActiveChanged =
-      new ChromeStreamController<OnActiveChangedEvent>.twoArgs(_tabs, 'onActiveChanged', _createOnActiveChangedEvent);
-
-  /**
-   * Fires when the active tab in a window changes. Note that the tab's URL may
-   * not be set at the time this event fired, but you can listen to onUpdated
-   * events to be notified when a URL is set.
-   */
-  Stream<Map> get onActivated => _onActivated.stream;
-
-  final ChromeStreamController<Map> _onActivated =
-      new ChromeStreamController<Map>.oneArg(_tabs, 'onActivated', mapify);
-
-  /**
-   * Deprecated. Please use onHighlighted.
-   */
-  Stream<Map> get onHighlightChanged => _onHighlightChanged.stream;
-
-  final ChromeStreamController<Map> _onHighlightChanged =
-      new ChromeStreamController<Map>.oneArg(_tabs, 'onHighlightChanged', mapify);
-
-  /**
-   * Fired when the highlighted or selected tabs in a window changes.
-   */
-  Stream<Map> get onHighlighted => _onHighlighted.stream;
-
-  final ChromeStreamController<Map> _onHighlighted =
-      new ChromeStreamController<Map>.oneArg(_tabs, 'onHighlighted', mapify);
-
-  /**
-   * Fired when a tab is detached from a window, for example because it is being
-   * moved between windows.
-   */
-  Stream<OnDetachedEvent> get onDetached => _onDetached.stream;
-
-  final ChromeStreamController<OnDetachedEvent> _onDetached =
-      new ChromeStreamController<OnDetachedEvent>.twoArgs(_tabs, 'onDetached', _createOnDetachedEvent);
-
-  /**
-   * Fired when a tab is attached to a window, for example because it was moved
-   * between windows.
-   */
-  Stream<OnAttachedEvent> get onAttached => _onAttached.stream;
-
-  final ChromeStreamController<OnAttachedEvent> _onAttached =
-      new ChromeStreamController<OnAttachedEvent>.twoArgs(_tabs, 'onAttached', _createOnAttachedEvent);
-
-  /**
-   * Fired when a tab is closed.
-   */
-  Stream<TabsOnRemovedEvent> get onRemoved => _onRemoved.stream;
-
-  final ChromeStreamController<TabsOnRemovedEvent> _onRemoved =
-      new ChromeStreamController<TabsOnRemovedEvent>.twoArgs(_tabs, 'onRemoved', _createOnRemovedEvent);
-
-  /**
-   * Fired when a tab is replaced with another tab due to prerendering or
-   * instant.
-   */
-  Stream<OnReplacedEvent> get onReplaced => _onReplaced.stream;
-
-  final ChromeStreamController<OnReplacedEvent> _onReplaced =
-      new ChromeStreamController<OnReplacedEvent>.twoArgs(_tabs, 'onReplaced', _createOnReplacedEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.tabs' is not available");
@@ -989,8 +991,6 @@ class TabsCaptureVisibleTabParams extends ChromeObject {
 }
 
 Tab _createTab(JsObject jsProxy) => jsProxy == null ? null : new Tab.fromProxy(jsProxy);
-Port _createPort(JsObject jsProxy) => jsProxy == null ? null : new Port.fromProxy(jsProxy);
-Window _createWindow(JsObject jsProxy) => jsProxy == null ? null : new Window.fromProxy(jsProxy);
 OnUpdatedEvent _createOnUpdatedEvent(int tabId, JsObject changeInfo, JsObject tab) =>
     new OnUpdatedEvent(tabId, mapify(changeInfo), _createTab(tab));
 TabsOnMovedEvent _createOnMovedEvent(int tabId, JsObject moveInfo) =>
@@ -1007,3 +1007,5 @@ TabsOnRemovedEvent _createOnRemovedEvent(int tabId, JsObject removeInfo) =>
     new TabsOnRemovedEvent(tabId, mapify(removeInfo));
 OnReplacedEvent _createOnReplacedEvent(int addedTabId, int removedTabId) =>
     new OnReplacedEvent(addedTabId, removedTabId);
+Port _createPort(JsObject jsProxy) => jsProxy == null ? null : new Port.fromProxy(jsProxy);
+Window _createWindow(JsObject jsProxy) => jsProxy == null ? null : new Window.fromProxy(jsProxy);

--- a/lib/gen/top_sites.dart
+++ b/lib/gen/top_sites.dart
@@ -14,7 +14,7 @@ import '../src/common.dart';
 final ChromeTopSites topSites = new ChromeTopSites._();
 
 class ChromeTopSites extends ChromeApi {
-  static final JsObject _topSites = chrome['topSites'];
+  JsObject get _topSites => chrome['topSites'];
 
   ChromeTopSites._();
 

--- a/lib/gen/tts.dart
+++ b/lib/gen/tts.dart
@@ -16,9 +16,19 @@ import '../src/common.dart';
 final ChromeTts tts = new ChromeTts._();
 
 class ChromeTts extends ChromeApi {
-  static final JsObject _tts = chrome['tts'];
+  JsObject get _tts => chrome['tts'];
 
-  ChromeTts._();
+  /**
+   * Used to pass events back to the function calling speak().
+   */
+  Stream<TtsEvent> get onEvent => _onEvent.stream;
+  ChromeStreamController<TtsEvent> _onEvent;
+
+  ChromeTts._() {
+    var getApi = () => _tts;
+    _onEvent =
+        new ChromeStreamController<TtsEvent>.oneArg(getApi, 'onEvent', _createTtsEvent);
+  }
 
   bool get available => _tts != null;
 
@@ -100,14 +110,6 @@ class ChromeTts extends ChromeApi {
     _tts.callMethod('getVoices', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Used to pass events back to the function calling speak().
-   */
-  Stream<TtsEvent> get onEvent => _onEvent.stream;
-
-  final ChromeStreamController<TtsEvent> _onEvent =
-      new ChromeStreamController<TtsEvent>.oneArg(_tts, 'onEvent', _createTtsEvent);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.tts' is not available");
@@ -298,5 +300,5 @@ class TtsSpeakParams extends ChromeObject {
   set onEvent(var value) => jsProxy['onEvent'] = jsify(value);
 }
 
-TtsVoice _createTtsVoice(JsObject jsProxy) => jsProxy == null ? null : new TtsVoice.fromProxy(jsProxy);
 TtsEvent _createTtsEvent(JsObject jsProxy) => jsProxy == null ? null : new TtsEvent.fromProxy(jsProxy);
+TtsVoice _createTtsVoice(JsObject jsProxy) => jsProxy == null ? null : new TtsVoice.fromProxy(jsProxy);

--- a/lib/gen/types.dart
+++ b/lib/gen/types.dart
@@ -13,7 +13,7 @@ import '../src/common.dart';
 final ChromeTypes types = new ChromeTypes._();
 
 class ChromeTypes extends ChromeApi {
-  static final JsObject _types = chrome['types'];
+  JsObject get _types => chrome['types'];
 
   ChromeTypes._();
 

--- a/lib/gen/usb.dart
+++ b/lib/gen/usb.dart
@@ -15,7 +15,7 @@ import '../src/common.dart';
 final ChromeUsb usb = new ChromeUsb._();
 
 class ChromeUsb extends ChromeApi {
-  static final JsObject _usb = chrome['usb'];
+  JsObject get _usb => chrome['usb'];
 
   ChromeUsb._();
 

--- a/lib/gen/wallpaper.dart
+++ b/lib/gen/wallpaper.dart
@@ -13,7 +13,7 @@ import '../src/common.dart';
 final ChromeWallpaper wallpaper = new ChromeWallpaper._();
 
 class ChromeWallpaper extends ChromeApi {
-  static final JsObject _wallpaper = chrome['wallpaper'];
+  JsObject get _wallpaper => chrome['wallpaper'];
 
   ChromeWallpaper._();
 

--- a/lib/gen/web_navigation.dart
+++ b/lib/gen/web_navigation.dart
@@ -14,9 +14,93 @@ import '../src/common.dart';
 final ChromeWebNavigation webNavigation = new ChromeWebNavigation._();
 
 class ChromeWebNavigation extends ChromeApi {
-  static final JsObject _webNavigation = chrome['webNavigation'];
+  JsObject get _webNavigation => chrome['webNavigation'];
 
-  ChromeWebNavigation._();
+  /**
+   * Fired when a navigation is about to occur.
+   */
+  Stream<Map> get onBeforeNavigate => _onBeforeNavigate.stream;
+  ChromeStreamController<Map> _onBeforeNavigate;
+
+  /**
+   * Fired when a navigation is committed. The document (and the resources it
+   * refers to, such as images and subframes) might still be downloading, but at
+   * least part of the document has been received from the server and the
+   * browser has decided to switch to the new document.
+   */
+  Stream<Map> get onCommitted => _onCommitted.stream;
+  ChromeStreamController<Map> _onCommitted;
+
+  /**
+   * Fired when the page's DOM is fully constructed, but the referenced
+   * resources may not finish loading.
+   */
+  Stream<Map> get onDOMContentLoaded => _onDOMContentLoaded.stream;
+  ChromeStreamController<Map> _onDOMContentLoaded;
+
+  /**
+   * Fired when a document, including the resources it refers to, is completely
+   * loaded and initialized.
+   */
+  Stream<Map> get onCompleted => _onCompleted.stream;
+  ChromeStreamController<Map> _onCompleted;
+
+  /**
+   * Fired when an error occurs and the navigation is aborted. This can happen
+   * if either a network error occurred, or the user aborted the navigation.
+   */
+  Stream<Map> get onErrorOccurred => _onErrorOccurred.stream;
+  ChromeStreamController<Map> _onErrorOccurred;
+
+  /**
+   * Fired when a new window, or a new tab in an existing window, is created to
+   * host a navigation.
+   */
+  Stream<Map> get onCreatedNavigationTarget => _onCreatedNavigationTarget.stream;
+  ChromeStreamController<Map> _onCreatedNavigationTarget;
+
+  /**
+   * Fired when the reference fragment of a frame was updated. All future events
+   * for that frame will use the updated URL.
+   */
+  Stream<Map> get onReferenceFragmentUpdated => _onReferenceFragmentUpdated.stream;
+  ChromeStreamController<Map> _onReferenceFragmentUpdated;
+
+  /**
+   * Fired when the contents of the tab is replaced by a different (usually
+   * previously pre-rendered) tab.
+   */
+  Stream<Map> get onTabReplaced => _onTabReplaced.stream;
+  ChromeStreamController<Map> _onTabReplaced;
+
+  /**
+   * Fired when the frame's history was updated to a new URL. All future events
+   * for that frame will use the updated URL.
+   */
+  Stream<Map> get onHistoryStateUpdated => _onHistoryStateUpdated.stream;
+  ChromeStreamController<Map> _onHistoryStateUpdated;
+
+  ChromeWebNavigation._() {
+    var getApi = () => _webNavigation;
+    _onBeforeNavigate =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onBeforeNavigate', mapify);
+    _onCommitted =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onCommitted', mapify);
+    _onDOMContentLoaded =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onDOMContentLoaded', mapify);
+    _onCompleted =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onCompleted', mapify);
+    _onErrorOccurred =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onErrorOccurred', mapify);
+    _onCreatedNavigationTarget =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onCreatedNavigationTarget', mapify);
+    _onReferenceFragmentUpdated =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onReferenceFragmentUpdated', mapify);
+    _onTabReplaced =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onTabReplaced', mapify);
+    _onHistoryStateUpdated =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onHistoryStateUpdated', mapify);
+  }
 
   bool get available => _webNavigation != null;
 
@@ -54,88 +138,6 @@ class ChromeWebNavigation extends ChromeApi {
     _webNavigation.callMethod('getAllFrames', [jsify(details), completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a navigation is about to occur.
-   */
-  Stream<Map> get onBeforeNavigate => _onBeforeNavigate.stream;
-
-  final ChromeStreamController<Map> _onBeforeNavigate =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onBeforeNavigate', mapify);
-
-  /**
-   * Fired when a navigation is committed. The document (and the resources it
-   * refers to, such as images and subframes) might still be downloading, but at
-   * least part of the document has been received from the server and the
-   * browser has decided to switch to the new document.
-   */
-  Stream<Map> get onCommitted => _onCommitted.stream;
-
-  final ChromeStreamController<Map> _onCommitted =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onCommitted', mapify);
-
-  /**
-   * Fired when the page's DOM is fully constructed, but the referenced
-   * resources may not finish loading.
-   */
-  Stream<Map> get onDOMContentLoaded => _onDOMContentLoaded.stream;
-
-  final ChromeStreamController<Map> _onDOMContentLoaded =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onDOMContentLoaded', mapify);
-
-  /**
-   * Fired when a document, including the resources it refers to, is completely
-   * loaded and initialized.
-   */
-  Stream<Map> get onCompleted => _onCompleted.stream;
-
-  final ChromeStreamController<Map> _onCompleted =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onCompleted', mapify);
-
-  /**
-   * Fired when an error occurs and the navigation is aborted. This can happen
-   * if either a network error occurred, or the user aborted the navigation.
-   */
-  Stream<Map> get onErrorOccurred => _onErrorOccurred.stream;
-
-  final ChromeStreamController<Map> _onErrorOccurred =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onErrorOccurred', mapify);
-
-  /**
-   * Fired when a new window, or a new tab in an existing window, is created to
-   * host a navigation.
-   */
-  Stream<Map> get onCreatedNavigationTarget => _onCreatedNavigationTarget.stream;
-
-  final ChromeStreamController<Map> _onCreatedNavigationTarget =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onCreatedNavigationTarget', mapify);
-
-  /**
-   * Fired when the reference fragment of a frame was updated. All future events
-   * for that frame will use the updated URL.
-   */
-  Stream<Map> get onReferenceFragmentUpdated => _onReferenceFragmentUpdated.stream;
-
-  final ChromeStreamController<Map> _onReferenceFragmentUpdated =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onReferenceFragmentUpdated', mapify);
-
-  /**
-   * Fired when the contents of the tab is replaced by a different (usually
-   * previously pre-rendered) tab.
-   */
-  Stream<Map> get onTabReplaced => _onTabReplaced.stream;
-
-  final ChromeStreamController<Map> _onTabReplaced =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onTabReplaced', mapify);
-
-  /**
-   * Fired when the frame's history was updated to a new URL. All future events
-   * for that frame will use the updated URL.
-   */
-  Stream<Map> get onHistoryStateUpdated => _onHistoryStateUpdated.stream;
-
-  final ChromeStreamController<Map> _onHistoryStateUpdated =
-      new ChromeStreamController<Map>.oneArg(_webNavigation, 'onHistoryStateUpdated', mapify);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.webNavigation' is not available");

--- a/lib/gen/web_request.dart
+++ b/lib/gen/web_request.dart
@@ -14,9 +14,93 @@ import '../src/common.dart';
 final ChromeWebRequest webRequest = new ChromeWebRequest._();
 
 class ChromeWebRequest extends ChromeApi {
-  static final JsObject _webRequest = chrome['webRequest'];
+  JsObject get _webRequest => chrome['webRequest'];
 
-  ChromeWebRequest._();
+  /**
+   * Fired when a request is about to occur.
+   */
+  Stream<Map> get onBeforeRequest => _onBeforeRequest.stream;
+  ChromeStreamController<Map> _onBeforeRequest;
+
+  /**
+   * Fired before sending an HTTP request, once the request headers are
+   * available. This may occur after a TCP connection is made to the server, but
+   * before any HTTP data is sent.
+   */
+  Stream<Map> get onBeforeSendHeaders => _onBeforeSendHeaders.stream;
+  ChromeStreamController<Map> _onBeforeSendHeaders;
+
+  /**
+   * Fired just before a request is going to be sent to the server
+   * (modifications of previous onBeforeSendHeaders callbacks are visible by the
+   * time onSendHeaders is fired).
+   */
+  Stream<Map> get onSendHeaders => _onSendHeaders.stream;
+  ChromeStreamController<Map> _onSendHeaders;
+
+  /**
+   * Fired when HTTP response headers of a request have been received.
+   */
+  Stream<Map> get onHeadersReceived => _onHeadersReceived.stream;
+  ChromeStreamController<Map> _onHeadersReceived;
+
+  /**
+   * Fired when an authentication failure is received. The listener has three
+   * options: it can provide authentication credentials, it can cancel the
+   * request and display the error page, or it can take no action on the
+   * challenge. If bad user credentials are provided, this may be called
+   * multiple times for the same request.
+   */
+  Stream<OnAuthRequiredEvent> get onAuthRequired => _onAuthRequired.stream;
+  ChromeStreamController<OnAuthRequiredEvent> _onAuthRequired;
+
+  /**
+   * Fired when the first byte of the response body is received. For HTTP
+   * requests, this means that the status line and response headers are
+   * available.
+   */
+  Stream<Map> get onResponseStarted => _onResponseStarted.stream;
+  ChromeStreamController<Map> _onResponseStarted;
+
+  /**
+   * Fired when a server-initiated redirect is about to occur.
+   */
+  Stream<Map> get onBeforeRedirect => _onBeforeRedirect.stream;
+  ChromeStreamController<Map> _onBeforeRedirect;
+
+  /**
+   * Fired when a request is completed.
+   */
+  Stream<Map> get onCompleted => _onCompleted.stream;
+  ChromeStreamController<Map> _onCompleted;
+
+  /**
+   * Fired when an error occurs.
+   */
+  Stream<Map> get onErrorOccurred => _onErrorOccurred.stream;
+  ChromeStreamController<Map> _onErrorOccurred;
+
+  ChromeWebRequest._() {
+    var getApi = () => _webRequest;
+    _onBeforeRequest =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onBeforeRequest', mapify);
+    _onBeforeSendHeaders =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onBeforeSendHeaders', mapify);
+    _onSendHeaders =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onSendHeaders', mapify);
+    _onHeadersReceived =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onHeadersReceived', mapify);
+    _onAuthRequired =
+        new ChromeStreamController<OnAuthRequiredEvent>.twoArgs(getApi, 'onAuthRequired', _createOnAuthRequiredEvent);
+    _onResponseStarted =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onResponseStarted', mapify);
+    _onBeforeRedirect =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onBeforeRedirect', mapify);
+    _onCompleted =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onCompleted', mapify);
+    _onErrorOccurred =
+        new ChromeStreamController<Map>.oneArg(getApi, 'onErrorOccurred', mapify);
+  }
 
   bool get available => _webRequest != null;
 
@@ -39,88 +123,6 @@ class ChromeWebRequest extends ChromeApi {
     _webRequest.callMethod('handlerBehaviorChanged', [completer.callback]);
     return completer.future;
   }
-
-  /**
-   * Fired when a request is about to occur.
-   */
-  Stream<Map> get onBeforeRequest => _onBeforeRequest.stream;
-
-  final ChromeStreamController<Map> _onBeforeRequest =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onBeforeRequest', mapify);
-
-  /**
-   * Fired before sending an HTTP request, once the request headers are
-   * available. This may occur after a TCP connection is made to the server, but
-   * before any HTTP data is sent.
-   */
-  Stream<Map> get onBeforeSendHeaders => _onBeforeSendHeaders.stream;
-
-  final ChromeStreamController<Map> _onBeforeSendHeaders =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onBeforeSendHeaders', mapify);
-
-  /**
-   * Fired just before a request is going to be sent to the server
-   * (modifications of previous onBeforeSendHeaders callbacks are visible by the
-   * time onSendHeaders is fired).
-   */
-  Stream<Map> get onSendHeaders => _onSendHeaders.stream;
-
-  final ChromeStreamController<Map> _onSendHeaders =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onSendHeaders', mapify);
-
-  /**
-   * Fired when HTTP response headers of a request have been received.
-   */
-  Stream<Map> get onHeadersReceived => _onHeadersReceived.stream;
-
-  final ChromeStreamController<Map> _onHeadersReceived =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onHeadersReceived', mapify);
-
-  /**
-   * Fired when an authentication failure is received. The listener has three
-   * options: it can provide authentication credentials, it can cancel the
-   * request and display the error page, or it can take no action on the
-   * challenge. If bad user credentials are provided, this may be called
-   * multiple times for the same request.
-   */
-  Stream<OnAuthRequiredEvent> get onAuthRequired => _onAuthRequired.stream;
-
-  final ChromeStreamController<OnAuthRequiredEvent> _onAuthRequired =
-      new ChromeStreamController<OnAuthRequiredEvent>.twoArgs(_webRequest, 'onAuthRequired', _createOnAuthRequiredEvent);
-
-  /**
-   * Fired when the first byte of the response body is received. For HTTP
-   * requests, this means that the status line and response headers are
-   * available.
-   */
-  Stream<Map> get onResponseStarted => _onResponseStarted.stream;
-
-  final ChromeStreamController<Map> _onResponseStarted =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onResponseStarted', mapify);
-
-  /**
-   * Fired when a server-initiated redirect is about to occur.
-   */
-  Stream<Map> get onBeforeRedirect => _onBeforeRedirect.stream;
-
-  final ChromeStreamController<Map> _onBeforeRedirect =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onBeforeRedirect', mapify);
-
-  /**
-   * Fired when a request is completed.
-   */
-  Stream<Map> get onCompleted => _onCompleted.stream;
-
-  final ChromeStreamController<Map> _onCompleted =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onCompleted', mapify);
-
-  /**
-   * Fired when an error occurs.
-   */
-  Stream<Map> get onErrorOccurred => _onErrorOccurred.stream;
-
-  final ChromeStreamController<Map> _onErrorOccurred =
-      new ChromeStreamController<Map>.oneArg(_webRequest, 'onErrorOccurred', mapify);
 
   void _throwNotAvailable() {
     throw new UnsupportedError("'chrome.webRequest' is not available");

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -119,13 +119,14 @@ class ChromeCompleter<T> {
 }
 
 class ChromeStreamController<T> {
-  final JsObject _api;
+  JsObject get _api => _apiProvider();
+  final Function _apiProvider;
   final String _eventName;
   StreamController<T> _controller = new StreamController<T>.broadcast();
   bool _handlerAdded = false;
   Function _listener;
 
-  ChromeStreamController.noArgs(this._api, this._eventName) {
+  ChromeStreamController.noArgs(this._apiProvider, this._eventName) {
     _controller = new StreamController<T>.broadcast(
         onListen: _ensureHandlerAdded, onCancel: _removeHandler);
     _listener = () {
@@ -133,7 +134,7 @@ class ChromeStreamController<T> {
     };
   }
 
-  ChromeStreamController.oneArg(this._api, this._eventName, Function transformer, [returnVal])  {
+  ChromeStreamController.oneArg(this._apiProvider, this._eventName, Function transformer, [returnVal])  {
     _controller = new StreamController<T>.broadcast(
         onListen: _ensureHandlerAdded, onCancel: _removeHandler);
     _listener = ([arg1]) {
@@ -142,7 +143,7 @@ class ChromeStreamController<T> {
     };
   }
 
-  ChromeStreamController.twoArgs(this._api, this._eventName, Function transformer, [returnVal]) {
+  ChromeStreamController.twoArgs(this._apiProvider, this._eventName, Function transformer, [returnVal]) {
     _controller = new StreamController<T>.broadcast(
         onListen: _ensureHandlerAdded, onCancel: _removeHandler);
     _listener = ([arg1, arg2]) {
@@ -151,7 +152,7 @@ class ChromeStreamController<T> {
     };
   }
 
-  ChromeStreamController.threeArgs(this._api, this._eventName, Function transformer, [returnVal]) {
+  ChromeStreamController.threeArgs(this._apiProvider, this._eventName, Function transformer, [returnVal]) {
     _controller = new StreamController<T>.broadcast(
         onListen: _ensureHandlerAdded, onCancel: _removeHandler);
     _listener = ([arg1, arg2, arg3]) {


### PR DESCRIPTION
While `chrome.permissions` does properly add/remove permissions, there's a problem with assigning the `JsObject` namespace as a `final` variable that prevents it from working.

``` dart
class ChromeIdentity extends ChromeApi {
  static final JsObject _identity = chrome['identity'];
  bool get available => _identity != null;
}
```

As above, `_identity` is set at instantiation.  If the permission isn't granted at that point, `available` will evaluate to `false`.  Later if the permission is added through `chrome.permissions`, `available` will continue to evaluate to `false` because `_identity` is `final`.  This causes `UnsupportedError()` to be thrown even when the API has become supported.

This solution uses a getter to fetch the `JsObject` namespace, so if it is exposed later, it would then be accessible.

``` dart
class ChromePermissions extends ChromeApi {
  JsObject get _permissions => chrome['permissions'];
  bool get available => _permissions != null;
}
```

Unfortunately this also requires a change to `ChromeStreamController` which wants a reference to the namespace.  This solution passes a function returning the `JsObject` to the `ChromeStreamController`.

``` dart
class ChromeStreamController<T> {
  JsObject get _api => _apiProvider();
  final Function _apiProvider;
}
```

The `ChromeStreamController` are instantiated as below:

``` dart
  ChromePermissions._() {
    var getApi = () => _permissions;
    _onAdded =
        new ChromeStreamController<Permissions>.oneArg(getApi, 'onAdded', _createPermissions);
    _onRemoved =
        new ChromeStreamController<Permissions>.oneArg(getApi, 'onRemoved', _createPermissions);
  }
```
