### PR TITLE
fix an issue w/ the hand-overridden API

### DIFF
--- a/lib/gen/app_patch.dart
+++ b/lib/gen/app_patch.dart
@@ -38,7 +38,7 @@ class AppWindow extends _AppWindow {
 
   Stream _streamFor(String event) {
     if (_streamMap[event] == null) {
-      _streamMap[event] = new ChromeStreamController.noArgs(jsProxy, event).stream;
+      _streamMap[event] = new ChromeStreamController.noArgs(() => jsProxy, event).stream;
     }
 
     return _streamMap[event];


### PR DESCRIPTION
The generated API for listening for events changed - updating the (1) hand-written uses of this API.
