### PR TITLE
fix an issue w/ event listeners in M35

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -169,14 +169,22 @@ class ChromeStreamController<T> {
 
   void _ensureHandlerAdded() {
     if (!_handlerAdded) {
-      _api[_eventName].callMethod('addListener', [_listener]);
+      // TODO: Workaround an issue where the event objects are not properly
+      // proxied in M35 and after.
+      var jsEvent = _api[_eventName];
+      JsObject event = (jsEvent is JsObject ? jsEvent : new JsObject.fromBrowserObject(jsEvent));
+      event.callMethod('addListener', [_listener]);
       _handlerAdded = true;
     }
   }
 
   void _removeHandler() {
     if (_handlerAdded) {
-      _api[_eventName].callMethod('removeListener', [_listener]);
+      // TODO: Workaround an issue where the event objects are not properly
+      // proxied in M35 and after.
+      var jsEvent = _api[_eventName];
+      JsObject event = (jsEvent is JsObject ? jsEvent : new JsObject.fromBrowserObject(jsEvent));
+      event.callMethod('removeListener', [_listener]);
       _handlerAdded = false;
     }
   }


### PR DESCRIPTION
This fixes (or at least works around) an issue where event objects are not properly proxied in M35 and later. This issue does not show up in M33, and I don't think in M34. This issue would cause any code trying to listen for network, storage, window, ... events to throw when compiled to JS on M35 or later.

@financeCoding 

https://github.com/dart-lang/spark/issues/1268
