### PR TITLE
support parsing deprecated attributes

### DIFF
--- a/tool/chrome_idl_mapping.dart
+++ b/tool/chrome_idl_mapping.dart
@@ -196,6 +196,13 @@ IDLAttributeDeclaration idlAttributeDeclarationMapping(List attributes) =>
 IDLAttribute idlAttributeAssignedValueMapping(String name, _, String value) =>
     new IDLAttribute(_resolveEnum(name), attributeValue: value);
 
+
+/**
+ *  Attribute where [name="string"]
+ */
+IDLAttribute idlAttributeAssignedStringLiteral(String name, _, String value) =>
+    new IDLAttribute(_resolveEnum(name), attributeValue: value);
+
 /**
  *  Attribute where [name=(1,2)]
  */

--- a/tool/chrome_idl_model.dart
+++ b/tool/chrome_idl_model.dart
@@ -169,9 +169,16 @@ class IDLAttributeTypeEnum {
 
   const IDLAttributeTypeEnum._(this.type);
 
-  static const List<IDLAttributeTypeEnum> values = const [INSTANCE_OF,
-    SUPPORTS_FILTER, NOINLINE_DOC, INLINE_DOC, NODOC, NOCOMPILE, LEGAL_VALUES,
-    PERMISSIONS, MAX_LISTENERS];
+  static const List<IDLAttributeTypeEnum> values = const [DEPRECATED,
+    INSTANCE_OF, SUPPORTS_FILTER, NOINLINE_DOC, INLINE_DOC, NODOC, NOCOMPILE,
+    LEGAL_VALUES, PERMISSIONS, MAX_LISTENERS];
+
+  /**
+   * Example:
+   *
+   *     [deprecated="Use innerBounds or outerBounds."]
+   */
+  static const DEPRECATED = const IDLAttributeTypeEnum._("deprecated");
 
   /**
    * Example:

--- a/tool/chrome_idl_parser.dart
+++ b/tool/chrome_idl_parser.dart
@@ -245,6 +245,9 @@ class ChromeIDLParser extends LanguageParsers {
       // Attribute where name=value
       (identifier + symbol('=') + identifier
       ^ idlAttributeAssignedValueMapping)
+      // Attribute where [name="string"]
+      | (identifier + symbol('=') + stringLiteral
+      ^ idlAttributeAssignedStringLiteral)
       // Attribute where [maxListeners=1]
       | (identifier + symbol('=') + natural
       ^ (name, _, number) =>


### PR DESCRIPTION
@financeCoding, it looks like there've been some changes in the idl format. Some new attributes, like deprecated. And a new way to specify params (return values?) that can be of one or more type. Also, files moved around in the idl/ directory.

This CL lets us parse the `deprecated` attribute. More work to follow -
