### PR TITLE
Properly parse `instanceOf` attribute object array.

### DIFF
--- a/idl/chrome/media_galleries.idl
+++ b/idl/chrome/media_galleries.idl
@@ -69,10 +69,10 @@ namespace mediaGalleries {
   };
 
   callback MediaFileSystemsCallback =
-      void ([instanceOf=DOMFileSystem] object mediaFileSystems);
+      void ([instanceOf=DOMFileSystem] object[] mediaFileSystems);
 
   callback AddUserFolderCallback =
-      void ([instanceOf=DOMFileSystem] object mediaFileSystems,
+      void ([instanceOf=DOMFileSystem] object[] mediaFileSystems,
             DOMString selectedFileSystemName);
 
   callback DropPermissionForMediaFileSystemCallback = void ();

--- a/test/chrome_idl_test.dart
+++ b/test/chrome_idl_test.dart
@@ -375,6 +375,24 @@ void chromeIDLParserCallbackParameterTypeTests() {
     expect(callbackParameterType.name, equals("Device"));
     expect(callbackParameterType.isArray, isFalse);
   });
+
+  test('callback parameter type with object array', () {
+
+    IDLType callbackParameterType = chromeIDLParser.callbackParameterType
+        .parse("object[]");
+    expect(callbackParameterType, isNotNull);
+    expect(callbackParameterType.name, equals("object"));
+    expect(callbackParameterType.isArray, isTrue);
+  });
+
+  test('callback parameter type without object array', () {
+
+    IDLType callbackParameterType = chromeIDLParser.callbackParameterType
+        .parse("object");
+    expect(callbackParameterType, isNotNull);
+    expect(callbackParameterType.name, equals("object"));
+    expect(callbackParameterType.isArray, isFalse);
+  });
 }
 
 void chromeIDLParserCallbackParameterTests() {
@@ -393,6 +411,23 @@ void chromeIDLParserCallbackParameterTests() {
         equals(IDLAttributeTypeEnum.INSTANCE_OF));
     expect(callbackParameter.attribute.attributes[0].attributeValue,
         equals("Entry"));
+  });
+
+  test('callback parameter with attribute object array', () {
+
+    IDLParameter callbackParameter = chromeIDLParser.callbackParameters
+        .parse("[instanceOf=DOMFileSystem] object[] mediaFileSystems");
+
+    expect(callbackParameter, isNotNull);
+    expect(callbackParameter.name, equals("mediaFileSystems"));
+    expect(callbackParameter.isCallback, isFalse);
+    expect(callbackParameter.isOptional, isFalse);
+    expect(callbackParameter.type.isArray, isTrue);
+    expect(callbackParameter.type.name, equals("DOMFileSystem"));
+    expect(callbackParameter.attribute.attributes[0].attributeType,
+        equals(IDLAttributeTypeEnum.INSTANCE_OF));
+    expect(callbackParameter.attribute.attributes[0].attributeValue,
+        equals("DOMFileSystem"));
   });
 
   test('callback parameter with optional', () {
@@ -468,6 +503,28 @@ void chromeIDLParserCallbackMethodTests() {
     expect(parameter.isOptional, isFalse);
     expect(parameter.type.isArray, isFalse);
     expect(parameter.type.name, equals("long"));
+  });
+
+  test('with one attribute parameter', () {
+
+    List<IDLParameter> parameters = chromeIDLParser.callbackMethod
+        .parse("void ([instanceOf=DOMFileSystem] object[] mediaFileSystems)");
+
+    expect(parameters, isNotNull);
+    expect(parameters.length, equals(1));
+    IDLParameter parameter = parameters[0];
+    expect(parameter.name, equals("mediaFileSystems"));
+    expect(parameter.attribute, isNotNull);
+    expect(parameter.attribute.attributes, isNotNull);
+    expect(parameter.attribute.attributes.length, equals(1));
+    expect(parameter.attribute.attributes[0].attributeType,
+        equals(IDLAttributeTypeEnum.INSTANCE_OF));
+    expect(parameter.attribute.attributes[0].attributeValue,
+        equals("DOMFileSystem"));
+    expect(parameter.isCallback, isFalse);
+    expect(parameter.isOptional, isFalse);
+    expect(parameter.type.isArray, isTrue);
+    expect(parameter.type.name, equals("DOMFileSystem"));
   });
 
   test('with multiple parameters', () {
@@ -666,6 +723,24 @@ void chromeIDLParserFieldTypeTests() {
         .parse("Device");
     expect(fieldType, isNotNull);
     expect(fieldType.name, equals("Device"));
+    expect(fieldType.isArray, isFalse);
+  });
+
+  test('field type object with array', () {
+
+    IDLType fieldType = chromeIDLParser.fieldType
+        .parse("object[]");
+    expect(fieldType, isNotNull);
+    expect(fieldType.name, equals("object"));
+    expect(fieldType.isArray, isTrue);
+  });
+
+  test('field type object without array', () {
+
+    IDLType fieldType = chromeIDLParser.fieldType
+        .parse("object");
+    expect(fieldType, isNotNull);
+    expect(fieldType.name, equals("object"));
     expect(fieldType.isArray, isFalse);
   });
 }

--- a/tool/chrome_idl_mapping.dart
+++ b/tool/chrome_idl_mapping.dart
@@ -96,26 +96,26 @@ IDLParameter idlParameterMapping(String name, IDLType type,
 /*
  * Mapping the type of an attribute.
  */
-IDLType _idlAttributeTypeMapping(IDLAttributeDeclaration attribute) {
+IDLType _idlAttributeTypeMapping(IDLAttributeDeclaration attribute, {isArray: false}) {
   IDLAttributeTypeEnum t = attribute.attributes[0].attributeType;
   if (t != IDLAttributeTypeEnum.INSTANCE_OF) {
     throw new ArgumentError(
         "attribute was not IDLAttributeTypeEnum.INSTANCE_OF");
   }
-  return new IDLType(attribute.attributes[0].attributeValue);
+  return new IDLType(attribute.attributes[0].attributeValue, isArray: isArray);
 }
 
 /**
  * Mapping of parameter with attribute based type specificed.
  */
 IDLParameter idlParameterAttributeBasedTypeMapping(String name,
-  IDLAttributeDeclaration attribute) {
+  IDLAttributeDeclaration attribute, {isArray: false}) {
 
   // Check if its a callback by name.
   bool isCallback = name == 'callback' || name == 'responseCallback';
 
   return new IDLParameter(name,
-      _idlAttributeTypeMapping(attribute),
+      _idlAttributeTypeMapping(attribute, isArray: isArray),
       attribute: attribute, isCallback: isCallback);
 }
 

--- a/tool/chrome_idl_parser.dart
+++ b/tool/chrome_idl_parser.dart
@@ -184,6 +184,12 @@ class ChromeIDLParser extends LanguageParsers {
           ^ (attribute, __, name) =>
               idlParameterAttributeBasedTypeMapping(name, attribute))
       |
+      // [instanceOf=DOMFileSystem] object[] mediaFileSystems
+      (attributeDeclaration + reserved["object"] + symbol('[') + symbol(']')
+          + identifier ^ (attribute, __, ___, ____, name) =>
+              idlParameterAttributeBasedTypeMapping(name, attribute,
+                  isArray: true))
+      |
       (attributeDeclaration
       + reserved["optional"]
       + callbackParameterType


### PR DESCRIPTION
@devoncarew should address https://github.com/dart-gde/chrome.dart/issues/178 

Generated `lib/gen/media_galleries.dart` 

``` diff
diff --git a/lib/gen/media_galleries.dart b/lib/gen/media_galleries.dart
index 68812e6..582511e 100644
--- a/lib/gen/media_galleries.dart
+++ b/lib/gen/media_galleries.dart
@@ -35,10 +35,10 @@ class ChromeMediaGalleries extends ChromeApi {
    * Get the media galleries configured in this user agent. If none are
    * configured or available, the callback will receive an empty array.
    */
-  Future<FileSystem> getMediaFileSystems([MediaFileSystemsDetails details]) {
+  Future<List<FileSystem>> getMediaFileSystems([MediaFileSystemsDetails details]) {
     if (_mediaGalleries == null) _throwNotAvailable();

-    var completer = new ChromeCompleter<FileSystem>.oneArg(_createDOMFileSystem);
+    var completer = new ChromeCompleter<List<FileSystem>>.oneArg((e) => listify(e, _createDOMFileSystem));
     _mediaGalleries.callMethod('getMediaFileSystems', [jsify(details), completer.callback]);
     return completer.future;
   }
@@ -100,10 +100,10 @@ class ChromeMediaGalleries extends ChromeApi {
    * has happened. All galleries the app has access to are returned, not just
    * the newly added galleries.
    */
-  Future<FileSystem> addScanResults() {
+  Future<List<FileSystem>> addScanResults() {
     if (_mediaGalleries == null) _throwNotAvailable();

-    var completer = new ChromeCompleter<FileSystem>.oneArg(_createDOMFileSystem);
+    var completer = new ChromeCompleter<List<FileSystem>>.oneArg((e) => listify(e, _createDOMFileSystem));
     _mediaGalleries.callMethod('addScanResults', [completer.callback]);
     return completer.future;
   }
@@ -400,10 +400,10 @@ class MediaMetadata extends ChromeObject {
  */
 class AddUserSelectedFolderResult {
   static AddUserSelectedFolderResult _create(mediaFileSystems, selectedFileSystemName) {
-    return new AddUserSelectedFolderResult._(_createDOMFileSystem(mediaFileSystems), selectedFileSystemName);
+    return new AddUserSelectedFolderResult._(listify(mediaFileSystems, _createDOMFileSystem), selectedFileSystemName);
   }

-  FileSystem mediaFileSystems;
+  List<FileSystem> mediaFileSystems;
   String selectedFileSystemName;

   AddUserSelectedFolderResult._(this.mediaFileSystems, this.selectedFileSystemName);
```
