### PR TITLE
csp loses the precompiled name

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -5,12 +5,12 @@
     for (var i = 0; i < scripts.length; ++i) {
       if (scripts[i].type == "application/dart" && scripts[i].src && scripts[i].src != '') {
         var script = document.createElement('script');
-        script.src = scripts[i].src.replace(/\.dart$/, '.dart.precompiled.js');
+        script.src = scripts[i].src.replace(/\.dart$/, '.dart.js');
         document.currentScript = script;
         scripts[i].parentNode.replaceChild(script, scripts[i]);
       } else if (scripts[i].src.indexOf('.dart.js') == scripts[i].src.length - 8) {
         var script = document.createElement('script');
-        script.src = scripts[i].src.replace(/\.dart\.js$/, '.dart.precompiled.js');
+        script.src = scripts[i].src.replace(/\.dart\.js$/, '.dart.js');
         document.currentScript = script;
         scripts[i].parentNode.replaceChild(script, scripts[i]);
       }

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -43,13 +43,13 @@ class ChromeTransformer extends Transformer {
    * Change:
    *     <script src="demo.dart" type="application/dart"></script>
    * to:
-   *     <script src="demo.dart.precompiled.js"></script>
+   *     <script src="demo.dart.js"></script>
    */
   String rewriteContent(String content) {
     Iterable<Match> matches = _regex1.allMatches(content).toList().reversed;
 
     for (Match match in matches) {
-      String newScript ='<script src="${match.group(1)}.precompiled.js"></script>';
+      String newScript ='<script src="${match.group(1)}.js"></script>';
       content = content.substring(0, match.start)
           + newScript + content.substring(match.end);
     }
@@ -57,7 +57,7 @@ class ChromeTransformer extends Transformer {
     matches = _regex2.allMatches(content).toList().reversed;
 
     for (Match match in matches) {
-      String newScript ='<script src="${match.group(1)}.precompiled.js"></script>';
+      String newScript ='<script src="${match.group(1)}.js"></script>';
       content = content.substring(0, match.start)
           + newScript + content.substring(match.end);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chrome
-version: 0.6.1-dev
+version: 0.6.1
 environment:
   sdk: ">=1.0.0 <2.0.0"
 authors:


### PR DESCRIPTION
Remove the `.precompiled` part of the dart2js file. dart2js will now take an explicit --csp flag, and output a normal file name.

@financeCoding 
