### PR TITLE
fix to the bootstrap script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog - chrome.dart
 
+## 0.6.4 2014-10-19
+- fixed an issue with double loading compiled JavaScript files
+
 ## 0.6.3 2014-08-29 (SDK 1.6.0-dev.9.7 r39537)
 - removed dependency loop in `files_exp.dart` and `files.dart`
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -8,11 +8,6 @@
         script.src = scripts[i].src.replace(/\.dart$/, '.dart.js');
         document.currentScript = script;
         scripts[i].parentNode.replaceChild(script, scripts[i]);
-      } else if (scripts[i].src.indexOf('.dart.js') == scripts[i].src.length - 8) {
-        var script = document.createElement('script');
-        script.src = scripts[i].src.replace(/\.dart\.js$/, '.dart.js');
-        document.currentScript = script;
-        scripts[i].parentNode.replaceChild(script, scripts[i]);
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chrome
-version: 0.6.3
+version: 0.6.4
 environment:
   sdk: ">=1.0.0 <2.0.0"
 authors:


### PR DESCRIPTION
Removed some legacy code to redirect form precompiled to foo.dart.js - erroneously updated when the precompiled files went away.

Probably tbr - @financeCoding 
