### PR TITLE
fix some warnings in generated code

### DIFF
--- a/lib/gen/app.dart
+++ b/lib/gen/app.dart
@@ -49,10 +49,6 @@ class ChromeAppRuntime extends ChromeApi {
   }
 
   bool get available => _app_runtime != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.app.runtime' is not available");
-  }
 }
 
 /**

--- a/lib/gen/content_settings.dart
+++ b/lib/gen/content_settings.dart
@@ -69,10 +69,6 @@ class ChromeContentSettings extends ChromeApi {
    * URL. The secondary URL is not used.
    */
   ContentSetting get notifications => _createContentSetting(_contentSettings['notifications']);
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.contentSettings' is not available");
-  }
 }
 
 /**

--- a/lib/gen/declarative_content.dart
+++ b/lib/gen/declarative_content.dart
@@ -26,10 +26,6 @@ class ChromeDeclarativeContent extends ChromeApi {
   }
 
   bool get available => _declarativeContent != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.declarativeContent' is not available");
-  }
 }
 
 /**

--- a/lib/gen/declarative_web_request.dart
+++ b/lib/gen/declarative_web_request.dart
@@ -39,10 +39,6 @@ class ChromeDeclarativeWebRequest extends ChromeApi {
   }
 
   bool get available => _declarativeWebRequest != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.declarativeWebRequest' is not available");
-  }
 }
 
 /**

--- a/lib/gen/events.dart
+++ b/lib/gen/events.dart
@@ -19,10 +19,6 @@ class ChromeEvents extends ChromeApi {
   ChromeEvents._();
 
   bool get available => _events != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.events' is not available");
-  }
 }
 
 /**

--- a/lib/gen/extension_types.dart
+++ b/lib/gen/extension_types.dart
@@ -19,10 +19,6 @@ class ChromeExtensionTypes extends ChromeApi {
   ChromeExtensionTypes._();
 
   bool get available => _extensionTypes != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.extensionTypes' is not available");
-  }
 }
 
 /**

--- a/lib/gen/privacy.dart
+++ b/lib/gen/privacy.dart
@@ -40,10 +40,6 @@ class ChromePrivacy extends ChromeApi {
    * websites.
    */
   WebsitesPrivacy get websites => _createWebsitesPrivacy(_privacy['websites']);
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.privacy' is not available");
-  }
 }
 
 class NetworkPrivacy extends ChromeObject {

--- a/lib/gen/proxy.dart
+++ b/lib/gen/proxy.dart
@@ -36,10 +36,6 @@ class ChromeProxy extends ChromeApi {
    * object.
    */
   ChromeSetting get settings => _createChromeSetting(_proxy['settings']);
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.proxy' is not available");
-  }
 }
 
 /**

--- a/lib/gen/storage.dart
+++ b/lib/gen/storage.dart
@@ -45,10 +45,6 @@ class ChromeStorage extends ChromeApi {
    * results in an error.
    */
   StorageArea get managed => _createStorageArea(_storage['managed']);
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.storage' is not available");
-  }
 }
 
 /**

--- a/lib/gen/types.dart
+++ b/lib/gen/types.dart
@@ -18,10 +18,6 @@ class ChromeTypes extends ChromeApi {
   ChromeTypes._();
 
   bool get available => _types != null;
-
-  void _throwNotAvailable() {
-    throw new UnsupportedError("'chrome.types' is not available");
-  }
 }
 
 /**


### PR DESCRIPTION
Fix some warnings in generated code - only generate a private method if it's used in that class.

@adambender 

```
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/content_settings.dart, line 73, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/declarative_content.dart, line 30, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/declarative_web_request.dart, line 43, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/events.dart, line 23, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/extension_types.dart, line 23, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/privacy.dart, line 44, col 8)
[hint] The method '_throwNotAvailable' is not used (/Users/devoncarew/projects/chrome.dart/lib/gen/proxy.dart, line 40, col 8)
```
