### PR TITLE
Don't assume working directory in tests

### DIFF
--- a/test/chrome_idl_files_test.dart
+++ b/test/chrome_idl_files_test.dart
@@ -1,9 +1,9 @@
 library test_chrome_idl_files;
 
-// TODO: also test test/idl/chrome/*.idl files
-
 import 'dart:io';
+import 'dart:mirrors';
 
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../tool/chrome_idl_parser.dart';
@@ -11,15 +11,21 @@ import '../tool/chrome_idl_convert.dart';
 import '../tool/chrome_idl_model.dart';
 
 void main() {
+  final String testDirectory = path.dirname(
+      currentMirrorSystem().findLibrary(#test_chrome_idl_files).uri.path);
+
   group('ChromeIDLParser', () {
     bool idlFileExtTest(FileSystemEntity file) => file.path.endsWith('.idl');
 
-    Iterable<FileSystemEntity> chromeIdlFileEntities = new Directory('idl')
-    .listSync(recursive: false, followLinks: false).where(idlFileExtTest);
+    Iterable<FileSystemEntity> chromeIdlFileEntities =
+        new Directory(path.join(testDirectory, '..', 'idl'))
+            .listSync(recursive: false, followLinks: false)
+            .where(idlFileExtTest);
 
     Iterable<FileSystemEntity> chromeIdlTestFileEntities =
-        new Directory('test/idl/chrome')
-    .listSync(recursive: false, followLinks: false).where(idlFileExtTest);
+        new Directory(path.join(testDirectory, 'idl', 'chrome'))
+            .listSync(recursive: false, followLinks: false)
+            .where(idlFileExtTest);
 
     List<FileSystemEntity> testFileEntities = new List<FileSystemEntity>()
       ..addAll(chromeIdlFileEntities)

--- a/test/model_json_test.dart
+++ b/test/model_json_test.dart
@@ -1,30 +1,37 @@
-
 library model_json_test;
 
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:mirrors';
 
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../tool/json_model.dart' as json_model;
 import '../tool/json_parser.dart' as json_parser;
 
 void main() {
+  final String testDirectory = path
+      .dirname(currentMirrorSystem().findLibrary(#model_json_test).uri.path);
+
   group('json_model', () {
     // Define a test for each .json file in idl/
     File testFile = new File('idl/extensions/runtime.json');
 
     // The unittest script likes to be run with the cwd set to the project root.
     if (testFile.existsSync()) {
-      Iterable<File> jsonFiles = new Directory('idl')
-          .listSync(recursive: true, followLinks: false)
-          .where((f) => f.path.endsWith('.json'));
+      Iterable<File> jsonFiles =
+          new Directory(path.join(testDirectory, '..', 'idl'))
+              .listSync(recursive: true, followLinks: false)
+              .where((f) => f.path.endsWith('.json'));
 
       for (File file in jsonFiles) {
         // skip _api_features.json, _manifest_features.json, _permission_features.json
-        if (!file.path.contains('/_') && !file.path.contains('test_presubmit')) {
+        if (!file.path.contains('/_') &&
+            !file.path.contains('test_presubmit')) {
           test(file.path, () {
-            json_model.JsonNamespace namespace = json_parser.parse(file.readAsStringSync());
+            json_model.JsonNamespace namespace =
+                json_parser.parse(file.readAsStringSync());
             expect(namespace.namespace, isNotNull);
           });
         }


### PR DESCRIPTION
We shouldn't assume test assets are in the current directory. Use mirrors to find out where the current test library is, as dart-lang/test#110 isn't resolved yet.

I also ran dartfmt over the two files I changed.