### PR TITLE
Adds new idl download tool

### DIFF
--- a/idl_readme.txt
+++ b/idl_readme.txt
@@ -1,17 +1,12 @@
-This directory contains copies of Chromium IDL files.
+The  idl directory contains copies of Chromium IDL and JSON files.
 
 The original files are from:
 
-  https://src.chromium.org/chrome/trunk/src/chrome/common/extensions/api
-  https://src.chromium.org/chrome/trunk/src/extensions/common/api
+  https://chromium.googlesource.com/chromium/src/+/<chrome_version>/chrome/common/extensions/api
+  https://chromium.googlesource.com/chromium/src/+/<chrome_version>/extensions/common/api
 
-SVN revisions available at http://omahaproxy.appspot.com/.
-Current revision: 283104
+GIT revisions available at http://omahaproxy.appspot.com/.
 
 To update:
 
-  rm -rf idl
-  svn co https://src.chromium.org/chrome/trunk/src/chrome/common/extensions/api idl/chrome -r <rev_number>
-  svn co https://src.chromium.org/chrome/trunk/src/extensions/common/api idl/extensions -r <rev_number>
-
-Please see the corresponding LICENSE file at: http://src.chromium.org/svn/trunk/src/LICENSE
+  dart tool/download_idls.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dev_dependencies:
   args: any
   browser: any
   logging: any
+  mockito: any
   parsers: '>=0.14.0 <0.15.0'
   path: any
   test: ^0.12.0

--- a/test/all.dart
+++ b/test/all.dart
@@ -1,12 +1,16 @@
 
 library all_test;
 
-import 'model_json_test.dart' as model_json_test;
-import 'src_gen_test.dart' as src_gen_test;
-import 'utils_test.dart' as utils_test;
-import 'chrome_idl_test.dart' as test_chrome_idl;
 import 'chrome_idl_files_test.dart' as test_chrome_idl_files;
+import 'chrome_idl_test.dart' as test_chrome_idl;
+import 'googlesource_test.dart' as googlesource_test;
+import 'model_json_test.dart' as model_json_test;
+import 'omaha_test.dart' as omaha_test;
+import 'simple_http_client_test.dart' as simple_http_client_test;
+import 'src_gen_test.dart' as src_gen_test;
+import 'tag_matcher_test.dart' as tag_matcher_test;
 import 'transformer_test.dart' as transformer_test;
+import 'utils_test.dart' as utils_test;
 
 void main() {
   model_json_test.main();
@@ -15,4 +19,8 @@ void main() {
   test_chrome_idl.main();
   test_chrome_idl_files.main();
   transformer_test.defineTests();
+  simple_http_client_test.defineTests();
+  omaha_test.defineTests();
+  tag_matcher_test.defineTests();
+  googlesource_test.defineTests();
 }

--- a/test/googlesource_test.dart
+++ b/test/googlesource_test.dart
@@ -1,0 +1,185 @@
+library googlesource_test;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import '../tool/src/googlesource.dart';
+import '../tool/src/simple_http_client.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('GoogleSourceFile', () {
+    GoogleSourceFile file;
+
+    void testHtmlConversion(List<String> lines) {
+      file = new GoogleSourceFile(asHtml(lines), 'example.com');
+
+      expect(file.fileContents, lines.join('\n'));
+    }
+
+    test('correctly parses simple raw html', () {
+      testHtmlConversion(['just one line']);
+    });
+
+    test('correctly parses multiline raw html', () {
+      testHtmlConversion(['multiple', 'small', 'lines']);
+    });
+
+    test('correctly parses multiline raw html with whitespace', () {
+      testHtmlConversion(['if (true)', '  goto label;', '', '', 'label']);
+    });
+
+    test('unescapes files', () {
+      var testEscapeString = 'this & that is <\"\'>';
+      var escapedHtmlFile = '<table><tr><td></td><td><a name="1"></a><span>'
+          '${HTML_ESCAPE.convert(testEscapeString)}</span></td></tr></table>';
+      file = new GoogleSourceFile(escapedHtmlFile, 'www.example.com');
+
+      expect(file.fileContents, testEscapeString);
+    });
+  });
+
+  group('GoogleSourceCrawler', () {
+    var baseUri = 'http://www.example.com/';
+    FakeSimpleHttpClient client;
+    GoogleSourceCrawler crawler;
+
+    setUp(() {
+      client = new FakeSimpleHttpClient();
+      crawler = new GoogleSourceCrawler(baseUri, client: client);
+    });
+
+    test('returns correct files in single directory', () async {
+      prepopulateHttpResponses(client, test1);
+
+      var files = await crawler.findAllMatchingFiles('test').toList();
+
+      expect(files.length, 3);
+      expect(
+          files.map((file) => file.url),
+          allOf(contains('/test/a.idl'), contains('/test/b.idl'),
+              contains('/test/c.idl')));
+    });
+
+    test('correctly follows the file tree', () async {
+      prepopulateHttpResponses(client, test2);
+
+      var files = await crawler.findAllMatchingFiles('test').toList();
+
+      expect(files.single.url, '/test/foo/bar/baz/qux.idl');
+    });
+
+    test('rejects files with non-matching extensions', () async {
+      prepopulateHttpResponses(client, test3);
+
+      var files = await crawler.findAllMatchingFiles('test').toList();
+
+      expect(files.length, 2);
+      expect(
+          files.map((file) => file.url),
+          allOf(contains('/test/a.idl'), contains('/test/c.json')));
+    });
+  });
+}
+
+void prepopulateHttpResponses(
+    FakeSimpleHttpClient fakeClient, List<String> responses) {
+  fakeClient.reset();
+  for (var response in responses) {
+    fakeClient.addHtml(response);
+  }
+}
+
+class FakeSimpleHttpClient implements SimpleHttpClient {
+  List<String> _htmlOutputList;
+  int _callCount;
+
+  FakeSimpleHttpClient() {
+    reset();
+  }
+
+  Future<String> getHtmlAtUri(_) {
+    var html = '';
+    if (_htmlOutputList.isNotEmpty) {
+      html = _htmlOutputList[_callCount];
+    }
+    if (_callCount != _htmlOutputList.length - 1) {
+      _callCount++;
+    }
+    return new Future.value(html);
+  }
+
+  void reset() {
+    _htmlOutputList = [];
+    _callCount = 0;
+  }
+
+  void addHtml(String html) {
+    _htmlOutputList.add(html);
+  }
+}
+
+var test1 = [
+  '<ol>'
+      '<li><a href="/test/a.idl">a.idl</a></li>'
+      '<li><a href="/test/b.idl">b.idl</a></li>'
+      '<li><a href="/test/c.idl">c.idl</a></li>'
+      '</ol>',
+  'a contents',
+  'b contents',
+  'c contents'
+];
+
+var test2 = [
+  '<ol><li><a href="/test/foo/">foo</a></li></ol>',
+  '<ol><li><a href="/test/foo/bar/">bar</a></li></ol>',
+  '<ol><li><a href="/test/foo/bar/baz/">baz</a></li></ol>',
+  '<ol><li><a href="/test/foo/bar/baz/qux.idl">qux.idl</a></li></ol>',
+  'qux contents'
+];
+
+var test3 = [
+  '<ol><li><a href="/test/a.idl">a.idl</a></li>'
+      '<li><a href="/test/b.txt">b.txt</a></li>'
+      '<li><a href="/test/c.json">c.json</a></li></ol>',
+  'a contents',
+  'b contents',
+  'c contents'
+];
+
+String asHtml(List<String> lines) {
+  var liHtml = lines
+      .map((line) => '<tr><td></td><td><a></a><span>$line</span></td></tr>')
+      .join();
+  return '<table>$liHtml</table>';
+}
+
+var multilineFileHtml = '''<table>
+  <tr>
+    <td></td>
+    <td><li><a name="1"></a><span>first line</span></li></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><li><a name="2"></a><span>  second line</span></li></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><li><a name="3"></a><span>just one line</span></li></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><li><a name="4"></a><span>just one line</span></li></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><li><a name="5"></a><span>just one line</span></li></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td><li><a name="6"></a><span>just one line</span></li></td>
+  </tr>
+</table>''';

--- a/test/omaha_test.dart
+++ b/test/omaha_test.dart
@@ -1,0 +1,36 @@
+library omaha_test;
+
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../tool/src/omaha.dart';
+import '../tool/src/simple_http_client.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('OmahaVersionExtractor', () {
+    OmahaVersionExtractor extractor;
+    MockSimpleHttpClient client;
+    String html;
+
+    setUp(() {
+      client = new MockSimpleHttpClient();
+      when(client.getHtmlAtUri(any)).thenAnswer((_) => new Future.value(html));
+      extractor = new OmahaVersionExtractor(client: client);
+    });
+
+    test('correctly parses good, simple input', () async {
+      var version = 'alpha';
+      html = 'mac,stable,$version';
+
+      expect(await extractor.stableVersion, version);
+    });
+  });
+}
+
+class MockSimpleHttpClient extends Mock implements SimpleHttpClient {
+  noSuchMethod(Invocation msg) => super.noSuchMethod(msg);
+}

--- a/test/simple_http_client_test.dart
+++ b/test/simple_http_client_test.dart
@@ -1,0 +1,53 @@
+library simple_http_client_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../tool/src/simple_http_client.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('SimpleHttpClient', () {
+    SimpleHttpClient simpleClient;
+    MockHttpClient mockClient;
+    MockHttpClientRequest mockRequest;
+    MockHttpClientResponse mockResponse;
+    List<String> html;
+
+    setUp(() {
+      mockClient = new MockHttpClient();
+      mockRequest = new MockHttpClientRequest();
+      mockResponse = new MockHttpClientResponse();
+
+      when(mockClient.getUrl(any)).thenReturn(mockRequest);
+      when(mockRequest.done).thenReturn(new Future(() => mockResponse));
+      when(mockResponse.transform(any)).thenAnswer((_) => html);
+
+      simpleClient = new SimpleHttpClient(client: mockClient);
+    });
+
+    test('returns string', () async {
+      var testString = 'this is some great testHtml';
+      html = [testString];
+
+      expect(await simpleClient.getHtmlAtUri(Uri.parse('example.com')),
+          testString);
+    });
+  });
+}
+
+class MockHttpClient extends Mock implements HttpClient {
+  noSuchMethod(Invocation msg) => super.noSuchMethod(msg);
+}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {
+  noSuchMethod(Invocation msg) => super.noSuchMethod(msg);
+}
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {
+  noSuchMethod(Invocation msg) => super.noSuchMethod(msg);
+}

--- a/test/tag_matcher_test.dart
+++ b/test/tag_matcher_test.dart
@@ -1,0 +1,69 @@
+library tag_matcher_test;
+
+import 'package:test/test.dart';
+
+import '../tool/src/tag_matcher.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('TagMatcher', () {
+    TagMatcher matcher;
+    var testString = 'Some untagged <span>This is some text in a span </span>'
+        '<a href="path/to/foo">foo link</a> <span>and back to span </span>';
+
+    test('matches tag contents correctly', () {
+      matcher = TagMatcher.spanMatcher;
+      var allContents = matcher.allContents(testString);
+
+      expect(allContents.length, 2);
+      expect(allContents.first, 'This is some text in a span ');
+      expect(allContents.last, 'and back to span ');
+    });
+
+    test('matches tag contents with attributes', () {
+      matcher = TagMatcher.aMatcher;
+      var allContents = matcher.allContents(testString);
+
+      expect(allContents.length, 1);
+      expect(allContents.first, 'foo link');
+    });
+
+    test('matches attributes, even when none are present, for all tags', () {
+      matcher = TagMatcher.anyTag;
+      var allAttributes = matcher.allAttributes(testString);
+
+      expect(allAttributes.length, 3);
+      // Neither span element has attributes.
+      expect(allAttributes.first.isEmpty, true);
+      expect(allAttributes.last.isEmpty, true);
+
+      var attributes = allAttributes.elementAt(1);
+
+      expect(attributes.length, 1);
+      expect(attributes['href'], 'path/to/foo');
+    });
+
+    group('matching attributes', () {
+      test('multiple tags have multiple attributes', () {
+        var lotsOfAttributes = '<li color="blue"></li><li color="black"></li>'
+            '<li size="big"    type="dog" color="red"></li>';
+        matcher = TagMatcher.liMatcher;
+
+        var allAttributes = matcher.allAttributes(lotsOfAttributes).toList();
+
+        expect(allAttributes[0].length, 1);
+        expect(allAttributes[0], containsPair('color', 'blue'));
+
+        expect(allAttributes[1].length, 1);
+        expect(allAttributes[1], containsPair('color', 'black'));
+
+        var cliffordAttributes = allAttributes[2];
+        expect(cliffordAttributes.length, 3);
+        expect(cliffordAttributes, containsPair('size', 'big'));
+        expect(cliffordAttributes, containsPair('type', 'dog'));
+        expect(cliffordAttributes, containsPair('color', 'red'));
+      });
+    });
+  });
+}

--- a/tool/download_idls.dart
+++ b/tool/download_idls.dart
@@ -1,0 +1,53 @@
+library download_idls;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'src/googlesource.dart';
+import 'src/omaha.dart';
+
+main() => new IdlDownloader().downloadIdls();
+
+class IdlDownloader {
+  static final _chromiumBaseUrl = 'https://chromium.googlesource.com';
+  static final _chromiumVersionPrefix = '/chromium/src/+/';
+  static final _idlDirs =
+      ['chrome/common/extensions/api', 'extensions/common/api'];
+
+  OmahaVersionExtractor _omahaVersionExtractor;
+  GoogleSourceCrawler _googleSourceCrawler;
+  String _version;
+
+  /// Finds the latest version of the Chrome IDL spec and downloads the files
+  /// to the appropriate local directories.
+  ///
+  /// The process is as follows: using the current version of Chrome, as
+  /// provided by the [OmahaVersionExtractor], we determine the path to the
+  /// source. Then, we crawl the source, with a [GoogleSourceCrawler], starting
+  /// in the directories we expect to find IDL and JSON files. Any files we
+  /// find, we download.
+  Future downloadIdls() async {
+    _omahaVersionExtractor = new OmahaVersionExtractor();
+    _version = await _omahaVersionExtractor.stableVersion;
+    print('Downloading IDL and JSON for APIs at Chrome $_version');
+    _googleSourceCrawler = new GoogleSourceCrawler(_chromiumBaseUrl);
+    for (var dir in _idlDirs) {
+      var relativePath = '$_chromiumVersionPrefix$_version/$dir';
+      _googleSourceCrawler
+          .findAllMatchingFiles(relativePath).listen(_downloadFile);
+    }
+  }
+
+  Future _downloadFile(GoogleSourceFile file) async {
+    var filePath = file.url.replaceFirst('/', '');
+    var localFile = new File(_resolvePath(filePath));
+    await localFile.create(recursive: true);
+    await localFile.writeAsString(file.fileContents);
+  }
+
+  String _resolvePath(String rawPath) {
+    var path = rawPath.replaceFirst(new RegExp('^.*[0-9]/'), '');
+    var prefix = path.split('/')[0];
+    return path.replaceFirst(new RegExp('.*/api'), 'idl/$prefix');
+  }
+}

--- a/tool/src/googlesource.dart
+++ b/tool/src/googlesource.dart
@@ -1,0 +1,89 @@
+library googlesource;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'simple_http_client.dart';
+import 'tag_matcher.dart';
+
+/// A [GoogleSourceEntity] represents either a file or a directory in the file
+/// system at chromium.googlesource.com. It knows its own [Uri] and the html
+/// source for the page at that Uri.
+abstract class GoogleSourceEntity {
+  final String _rawHtml;
+  final String _url;
+
+  GoogleSourceEntity(this._rawHtml, this._url);
+  String get url => _url;
+  String get _lines;
+}
+
+/// A [GoogleSourceFile] is a [GoogleSourceEntity] that represents a file. As
+/// such, it knows how to access its own contents.
+class GoogleSourceFile extends GoogleSourceEntity {
+  static const _encodedCharacters = const ['\'', '&', '<', '>', '\"'];
+  static final encodings =
+      new Map.fromIterable(_encodedCharacters, key: HTML_ESCAPE.convert);
+
+  GoogleSourceFile(rawHtml, url) : super(rawHtml, url);
+
+  /// Parse this file's raw html and return its contents.
+  String get fileContents => _unescapeHtml(new TagMatcher('tr')
+      .allContents(_lines)
+      .map((tableRow) {
+    var line = new TagMatcher('td').allContents(tableRow).toList()[1];
+    var lineStripped = line.replaceFirst(TagMatcher.aMatcher, '');
+    return TagMatcher.spanMatcher.allContents(lineStripped).join('');
+  }).join('\n'));
+
+  String _unescapeHtml(String escapedHtml) {
+    encodings.forEach((encodedString, decodedString) {
+      escapedHtml = escapedHtml.replaceAll(encodedString, decodedString);
+    });
+    return escapedHtml;
+  }
+
+  String get _lines => new TagMatcher('table').allContents(_rawHtml).single;
+}
+
+/// A [GoogleSourceDirectory] represents a directory and can access the [Uri]s
+/// of its child [GoogleSourceEntity]s.
+class GoogleSourceDirectory extends GoogleSourceEntity {
+  GoogleSourceDirectory(rawHtml, url) : super(rawHtml, url);
+
+  String get _lines => TagMatcher.olMatcher.allContents(_rawHtml).single;
+
+  Iterable<String> get listUris => TagMatcher.aMatcher
+      .allAttributes(_lines)
+      .map((Map<String, String> attributes) => attributes['href']);
+}
+
+/// A crawler that can take a [Uri] to a [GoogleSourceEntity], then traverse the
+/// directory (or file) that entity represents.
+class GoogleSourceCrawler {
+  static const matchingExtensions = const ['.idl', '.json'];
+
+  final SimpleHttpClient _client;
+  final String _baseUri;
+
+  GoogleSourceCrawler(this._baseUri, {SimpleHttpClient client})
+      : this._client = client ?? new SimpleHttpClient();
+
+  /// Asynchronously traverses the google source file system, starting from the
+  /// [GoogleSourceEntity] at [relativeUri], to find all [GoogleSourceFile]s
+  /// with extensions matching [matchingExtensions].
+  Stream<GoogleSourceFile> findAllMatchingFiles(String relativeUri) async* {
+    var directory = new GoogleSourceDirectory(
+        await _client.getHtmlAtUri(_absoluteUri(relativeUri)), relativeUri);
+    for (var childUrl in directory.listUris) {
+      if (childUrl.endsWith('/')) {
+        yield* findAllMatchingFiles(childUrl);
+      } else if (matchingExtensions.any((ext) => childUrl.endsWith(ext))) {
+        yield new GoogleSourceFile(
+            await _client.getHtmlAtUri(_absoluteUri(childUrl)), childUrl);
+      }
+    }
+  }
+
+  Uri _absoluteUri(String relativeUri) => Uri.parse('$_baseUri$relativeUri');
+}

--- a/tool/src/omaha.dart
+++ b/tool/src/omaha.dart
@@ -1,0 +1,29 @@
+library omaha;
+
+import 'dart:async';
+
+import 'simple_http_client.dart';
+
+/// This extractor parses the latest data at omahaproxy to determine the latest
+/// stable version of chrome.
+class OmahaVersionExtractor {
+  static const _omahaDataUrl = 'https://omahaproxy.appspot.com/all?csv=1';
+  static const _missingField = 'N/A';
+  static const _stableRelease = 'stable';
+  static const _stableOS = 'mac';
+
+  final SimpleHttpClient _client;
+
+  OmahaVersionExtractor({SimpleHttpClient client})
+      : this._client = client ?? new SimpleHttpClient();
+
+  Future<String> get stableVersion async {
+    var omahaData = await _client.getHtmlAtUri(Uri.parse(_omahaDataUrl));
+    var stableCommits = omahaData.split('\n')
+      ..removeWhere((line) =>
+          !line.contains(_stableRelease) || line.contains(_missingField));
+    var stableCommitVersions = new Map.fromIterable(stableCommits,
+        key: (line) => line.split(',')[0], value: (line) => line.split(',')[2]);
+    return stableCommitVersions[_stableOS];
+  }
+}

--- a/tool/src/simple_http_client.dart
+++ b/tool/src/simple_http_client.dart
@@ -1,0 +1,21 @@
+library simple_http_client;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Encapsulates an [HttpClient] for accessing HTML at a given [URI].
+class SimpleHttpClient {
+  final HttpClient _client;
+
+  SimpleHttpClient({HttpClient client})
+      : this._client = client ?? new HttpClient();
+
+  /// Download the HTML source of the page at the given [Uri].
+  Future<String> getHtmlAtUri(Uri uri) async {
+    HttpClientRequest request = await _client.getUrl(uri);
+    request.close();
+    HttpClientResponse response = await request.done;
+    return await response.transform(UTF8.decoder).join('');
+  }
+}

--- a/tool/src/tag_matcher.dart
+++ b/tool/src/tag_matcher.dart
@@ -1,0 +1,51 @@
+library tag_matcher;
+
+/// A [RegExp]-based matcher that can find attributes and contents of given tags
+/// in html or other markup.
+class TagMatcher implements Pattern {
+  static const _tagString = 'TAG';
+  static const _tagTemplate = '<$_tagString([^>]*)?>(.*?)</$_tagString>';
+  final _attributeMatcher = new RegExp('([^ ]*?)=\"(.*?)\"');
+  final String _tagName;
+  final RegExp _regExp;
+
+  static final anyTag = new TagMatcher('.*?');
+  static final olMatcher = new TagMatcher('ol');
+  static final liMatcher = new TagMatcher('li');
+  static final aMatcher = new TagMatcher('a');
+  static final spanMatcher = new TagMatcher('span');
+
+  TagMatcher(String tagName)
+      : _tagName = tagName,
+        _regExp = new RegExp(_tagTemplate.replaceAll(_tagString, tagName));
+
+  @override
+  Match matchAsPrefix(String string, [int start = 0]) =>
+      _regExp.matchAsPrefix(string, start);
+
+  @override
+  Iterable<Match> allMatches(String string, [int start = 0]) =>
+      _regExp.allMatches(string, start);
+
+  /// Given a string of html or xml, find all attributes for each tag matched by
+  /// this [TagMatcher]. Each tag's attributes are given as a [Map].
+  Iterable<Map<String, String>> allAttributes(String string, [int start = 0]) {
+    var attributesList = [];
+    _regExp.allMatches(string, start).forEach((match) {
+      var allAttributes = match.group(1);
+      attributesList.add(_makeAttributesMap(allAttributes));
+    });
+    return attributesList;
+  }
+
+  /// Given a string of html or other markup, find all of the contents of the
+  /// matching tags. For example, given the html '<div>foo</div><div>bar</div>',
+  /// calling this on a [TagMatcher] matching the div tag should return
+  /// ['foo','bar'].
+  Iterable<String> allContents(String string, [int start = 0]) =>
+      _regExp.allMatches(string, start).map((match) => match.group(2));
+
+  Map<String, String> _makeAttributesMap(String allAttributes) =>
+      new Map.fromIterable(_attributeMatcher.allMatches(allAttributes),
+          key: (match) => match.group(1), value: (match) => match.group(2));
+}


### PR DESCRIPTION
Adds a simple interface for making HTTP requests

Pulls down all html at a given URL

Wires simple http client into all tests

Adds omaha version extraction module

Also wires the omaha test into the test framework

Adds html tag matcher for parsing html.

Also wires tag matcher testing into main testing framework.

Adds googlesource library.

This library allows for crawling

Adds googlesource library.

This library allows for crawling the google source page and extracting the contents of files.

Wires googlesource library into testing

Also cleans up some of the library naming in tests

Adds some in progress work

Adds path resolution for file paths

Follows the convention of downloading files to idl/chrome/ and idl/extensions directories

Upgrade idl download tests to use test instead of unittest

Moves idl download utils into the src dir

Updates google source file parsing

Cleans up constructors using optional parameters

Updates directions for downloading latest IDL/JSON