### PR TITLE
Change async stubbing to use thenAnswer

### DIFF
--- a/tool/test/simple_http_client_test.dart
+++ b/tool/test/simple_http_client_test.dart
@@ -24,7 +24,7 @@ void defineTests() {
       mockResponse = new MockHttpClientResponse();
 
       when(mockClient.getUrl(any)).thenReturn(mockRequest);
-      when(mockRequest.done).thenReturn(new Future(() => mockResponse));
+      when(mockRequest.done).thenAnswer((_) => new Future(() => mockResponse));
       when(mockResponse.transform(any)).thenAnswer((_) => html);
 
       simpleClient = new SimpleHttpClient(client: mockClient);


### PR DESCRIPTION
Mockito now prohibits calling thenReturn with Futures and Streams. dart-lang/mockito#79