### PR TITLE
Accept optional ignored arg in ChromeCompleter.noArgs()

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -78,7 +78,7 @@ class ChromeCompleter<T> {
   Function _callback;
 
   ChromeCompleter.noArgs() {
-    this._callback = () {
+    this._callback = ([_]) {
       var le = lastError;
       if (le != null) {
         _completer.completeError(le);


### PR DESCRIPTION
Firefox at a minimum implements chrome.storage.local.set() (and possibly all async WebExtensions API with zero-arg callbacks) in such a way that the callback receives an explicit null parameter; no one in JS land is likely to notice, but Dart gets very mad.

By taking an optional parameter and throwing away its value, we guard against this possibility and fix compatibility of a fair bit of API with Firefox (and possibly other WebExtensions implementers).