### PR TITLE
Update package to work with dart:html with Chrome 63 IDL's.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog - chrome.dart
 
+## 0.9.4 018-04-06
+- updated to be compatible with Chrome 63 IDL's.
+
 ## 0.9.34 2018-03-09
 - fixes issues with firefox and optional args
 

--- a/lib/src/files.dart
+++ b/lib/src/files.dart
@@ -7,16 +7,16 @@ import 'dart:js';
 
 import 'dart:html' show
     Blob,
-    DirectoryEntry, DirectoryReader,
+    DirectoryEntry, DirectoryReader, DomException,
     Entry,
-    File, FileEntry, FileError, FileSystem, FileWriter,
+    File, FileEntry, FileSystem, FileWriter,
     Metadata;
 
 export 'dart:html' show
     Blob,
-    DirectoryEntry, DirectoryReader,
+    DirectoryEntry, DirectoryReader, DomException,
     Entry, EventTarget,
-    File, FileEntry, FileError, FileReader, FileSystem, FileWriter,
+    File, FileEntry, FileReader, FileSystem, FileWriter,
     Metadata,
     ProgressEvent;
 
@@ -427,7 +427,7 @@ class _ChromeCompleterWithError<T> {
   }
 }
 
-class CrFileError extends ChromeObject implements FileError {
+class CrFileError extends ChromeObject implements DomException {
   CrFileError.fromProxy(JsObject jsProxy) : super.fromProxy(jsProxy);
 
   int get code => jsProxy['code'];

--- a/lib/src/files_exp.dart
+++ b/lib/src/files_exp.dart
@@ -3,9 +3,9 @@ library chrome.src.files_exp;
 
 export 'dart:html' show
     Blob,
-    DirectoryEntry, DirectoryReader,
+    DirectoryEntry, DirectoryReader, DomException,
     Entry, EventTarget,
-    File, FileEntry, FileError, FileReader, FileSystem, FileWriter,
+    File, FileEntry, FileReader, FileSystem, FileWriter,
     Metadata,
     ProgressEvent;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chrome
-version: 0.9.34
+version: 0.9.4
 authors:
 - Adam Bender <adambender@gmail.com>
 - Ben Holtz <bholtz@cs.stanford.edu> 


### PR DESCRIPTION
In Dart SDK  2.0.0-dev.40.0, moved dart:html to using Chrome 63 IDL's. These changes are needed to get package chrome working with -dev.40.0 and beyond.